### PR TITLE
Add schema folder options

### DIFF
--- a/example/models/organization.ts
+++ b/example/models/organization.ts
@@ -1,0 +1,25 @@
+/**
+ * @swagger
+ * components:
+ *  schemas:
+ *    Organization:
+ *      type: object
+ *      properties:
+ *        id:
+ *          type: string
+ *          format: uuid
+ *        kode:
+ *          type: string
+ *        nama:
+ *          type: string
+ *        parent:
+ *          type: string
+ *        createdAt:
+ *          type: string
+ *          format: date-time
+ *        updatedAt:
+ *          type: string
+ *          format: date-time
+ */
+
+export default {};

--- a/example/pages/api/org.tsx
+++ b/example/pages/api/org.tsx
@@ -1,0 +1,30 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * @swagger
+ * /api/org:
+ *   get:
+ *     tags: [Organization]
+ *     responses:
+ *       200:
+ *         description: Organization
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 $ref: '#/components/schemas/Organization'
+ */
+interface OrgResponse{
+    message: string
+}
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<OrgResponse>
+) => {
+  res.status(200).json({message: "Organization"});
+};
+
+export default handler;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/with-swagger.ts
+++ b/src/with-swagger.ts
@@ -5,10 +5,12 @@ import swaggerJsdoc, { Options } from 'swagger-jsdoc';
 
 type SwaggerOptions = Options & {
   apiFolder?: string;
+  schemaFolder?: string;
 };
 
 const defaultOptions: SwaggerOptions = {
   apiFolder: 'pages/api',
+  schemaFolder: 'models',
   definition: {
     openapi: '3.0.0',
     info: {
@@ -22,25 +24,37 @@ const defaultOptions: SwaggerOptions = {
  * Create swagger JSON
  * @param options.openApiVersion Open API version {3.0.0}
  * @param options.apiFolder NextJS API folder {pages/api}
+ * @param options.schemaFolder entity schema folder
  * @param options.title Title
  * @param options.version Version
  * @returns Swagger JSON Spec
  */
 export function createSwaggerSpec({
   apiFolder = 'pages/api',
+  schemaFolder = 'models',
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   const apiDirectory = join(process.cwd(), apiFolder);
+  const schemaDirectory = join(process.cwd(), schemaFolder);
   const buildApiDirectory = join(process.cwd(), '.next/server', apiFolder);
+  const buildSchemaDirectory = join(
+    process.cwd(),
+    '.next/server',
+    schemaFolder
+  );
 
   const options: Options = {
-    ...swaggerOptions,
     apis: [
       `${apiDirectory}/**/*.js`,
       `${apiDirectory}/**/*.ts`,
       `${apiDirectory}/**/*.tsx`,
+      `${schemaDirectory}/**/*.js`,
+      `${schemaDirectory}/**/*.ts`,
+      `${schemaDirectory}/**/*.tsx`,
       `${buildApiDirectory}/**/*.js`,
+      `${buildSchemaDirectory}/**/*.js`,
     ], // files containing annotations as above
+    ...swaggerOptions,
   };
 
   return swaggerJsdoc(options);
@@ -56,6 +70,7 @@ export function createSwaggerSpec({
  */
 export function withSwagger({
   apiFolder = 'pages/api',
+  schemaFolder = 'models',
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   return () => {
@@ -63,6 +78,7 @@ export function withSwagger({
       try {
         const swaggerSpec = createSwaggerSpec({
           apiFolder,
+          schemaFolder,
           ...swaggerOptions,
         });
         res.status(200).send(swaggerSpec);


### PR DESCRIPTION
adding `schemaFolder` option in `makeSwagger` to get swagger component schemas spec from an entity file.

example (using TypeORM):
```
// /models/organization.model.ts
import {
  Column,
  Entity,
  Generated,
  ManyToOne,
  OneToMany,
  PrimaryColumn,
} from "typeorm";

/**
 * @swagger
 * components:
 *  schemas:
 *    Organization:
 *      type: object
 *      properties:
 *        id:
 *          type: string
 *          format: uuid
 *        name:
 *          type: string
 *        parent:
 *          type: string
 *        createdAt:
 *          type: string
 *          format: date-time
 *        updatedAt:
 *          type: string
 *          format: date-time
 */

@Entity()
export class Organization {
  @PrimaryColumn({ type: "uuid" })
  @Generated("uuid")
  id!: string;

  @Column() name!: string;

  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
  createdAt?: Date;

  @Column({
    type: "timestamp",
    default: () => "CURRENT_TIMESTAMP",
    onUpdate: "CURRENT_TIMESTAMP",
  })
  updatedAt?: Date;
}
```

and then, we can use this schema in our api route file:
```
// page/api/org/index.ts
...
/**
 * @swagger
 * /api/org:
 *   get:
 *     tags: [Organization]
 *     security:
 *       - bearerAuth: []
 *     responses:
 *       200:
 *         description: Organization
 *         content:
 *           application/json:
 *             schema:
 *               type: array
 *               items:
 *                 type: object
 *                 $ref: '#/components/schemas/Organization'
 */
....
```