### PR TITLE
feat: automatically add base path

### DIFF
--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,10 +1,12 @@
+/* eslint-disable no-underscore-dangle */
 import { NextApiRequest, NextApiResponse } from 'next';
 import { join } from 'path';
-import swaggerJsdoc, { Options } from 'swagger-jsdoc';
+import swaggerJsdoc, { OAS3Definition, Options } from 'swagger-jsdoc';
 
 type SwaggerOptions = Options & {
   apiFolder?: string;
   schemaFolders?: string[];
+  definition: OAS3Definition;
   outputFile?: string;
 };
 
@@ -52,9 +54,26 @@ export function createSwaggerSpec({
       ),
     ];
   });
+
+  // Append base path server element to server array
+  // Conditions: basePath is specified. Server array is not defined.
+  const definition = {
+    ...swaggerOptions.definition,
+    ...(process.env.__NEXT_ROUTER_BASEPATH
+      && !swaggerOptions.definition.servers && {
+      servers: [
+        {
+          url: process.env.__NEXT_ROUTER_BASEPATH,
+          description: 'next-js',
+        },
+      ],
+    }),
+  };
+
   const options: Options = {
     apis, // files containing annotations as above
-    ...swaggerOptions,
+    swaggerOptions,
+    definition,
   };
   const spec = swaggerJsdoc(options);
 

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -72,7 +72,7 @@ export function createSwaggerSpec({
 
   const options: Options = {
     apis, // files containing annotations as above
-    swaggerOptions,
+    ...swaggerOptions,
     definition,
   };
   const spec = swaggerJsdoc(options);


### PR DESCRIPTION
## WHAT
Next version 13.2 decided that the basePath is to be respected everywhere. That make the base path work out of the box (again). The API in Next is now definitely accessed under the base path. This PR takes this idea to next-swagger-doc, 

**If a basePath is specified, a matching server is created in the Open Api Specification 3.0.0.** 

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY
The routes specified on the api-docs page do not take basePath into consideration. Consequently, they lead to a error 404 when copied or executed.

The alternative in the current build is to specify the servers array in the swagger.ts definition. Of course you can do that, but it is another extra step to take if you want to move your next project to a base path, that you have to be aware of. This PR makes the swagger automatically adjust to the basePath. 

## HOW
Based on next.config.js. Reads process.env for the base path. This way it works for dev and production builds. If no basePath is specfied, nothing happens.

Otherwise, a server array is created and the basePath is added (this is the how you want to add a basePath, according to the documentation (https://swagger.io/docs/specification/api-host-and-base-path/))

While this might seem opinionated, it essentially only a default value. If the user has their own server specified, it is not added. Even an empty array overwrites the default. So this will not lock anyone into anything. I can't think of a reason why you wouldn't want this default, because if you use a base path, your API is needs to be accessed via that basePath. I can't think of a scenario  where this would be a breaking change for anyone.

I also tried using open api 2's basePath option by passing basePath as an option to the createSwaggerSpec function, with the hopes of not adding the server dropdown to the UI (which I personally find ugly), but that way did not work.

The code is kind of ugly, the first reason being that the info attribute is required in the SwaggerDefinition/OAS3Definition type, but is optional in the type of the default value's SwaggerOptions type. I also didn't want to add lodash as a dependency, so I wrote my own omit function.

It should be noted that this has no effect on the CLI. Support for the CLI could be added too.

## Screenshots (if appropriate):
![Screenshot 2023-02-28 194614](https://user-images.githubusercontent.com/14180064/221960784-23b7a3b8-5a9c-4239-a26d-df387489d991.png)


<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Linter
- [x] Tests
- [ ] Review comments
- [ ] Security
