### PR TITLE
apiFolder for src/pages/api vs pages/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ function ApiDoc({ spec }: InferGetStaticPropsType<typeof getStaticProps>) {
 
 export const getStaticProps: GetStaticProps = async () => {
   const spec: Record<string, any> = createSwaggerSpec({
+    apiFolder: 'pages/api' // or 'src/pages/api',
     definition: {
       openapi: '3.0.0',
       info: {


### PR DESCRIPTION
## WHAT
I've stumbled upon the issue with api-doc page not finding the swagger definition in my API route. After searching through the issues I found this discussion https://github.com/jellydn/next-swagger-doc/discussions/450. One of the comments there helped so I figured it'd save someone time to have it defined in the readme.

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY

## HOW

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security
