### PR TITLE
feat: generate docs from App Router routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ export async function GET(_request: Request) {
 }
 ```
 
+### Automatic App Router Documentation
+
+Set `autoDoc: true` to generate basic operations for App Router `route.ts` files.
+The path is derived from the route directory, dynamic segments such as `[id]`
+become `{id}`, and exported HTTP handlers such as `GET` and `POST` become
+operations. Generated operations include a default successful response; use a
+manual `@swagger` block when an endpoint needs request, response, or other
+operation metadata. Manual operations take precedence over generated ones.
+
+```javascript
+const spec = createSwaggerSpec({
+  apiFolder: 'app/api',
+  autoDoc: true,
+  definition: {
+    openapi: '3.0.0',
+    info: { title: 'My API', version: '1.0.0' },
+  },
+});
+```
+
 Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js application), and you should see the swagger UI.
 
 ![https://gyazo.com/6bfa919c4969b000615df6bb9cabcd02.gif](https://gyazo.com/6bfa919c4969b000615df6bb9cabcd02.gif)

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -99,7 +99,12 @@ function sanitizeSource(source: string): string {
       code += '\n';
     } else if (character === '/' && nextCharacter === '*') {
       const commentEnd = source.indexOf('*/', index + 2);
-      index = commentEnd === -1 ? source.length : commentEnd + 1;
+      if (commentEnd === -1) {
+        break;
+      }
+      code += ' ';
+      index = commentEnd + 2;
+      continue;
     } else if (character === "'" || character === '"' || character === '`') {
       const quote = character;
       index += 1;
@@ -193,6 +198,7 @@ export function extractApiInfo(
   }
 
   return Array.from(apiInfos.entries())
+    .sort(([firstPath], [secondPath]) => firstPath.localeCompare(secondPath))
     .map(([path, methods]) => ({
       path,
       methods: HTTP_METHODS.filter((method) =>

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -124,18 +124,7 @@ function getExportedMethods(source: string): string[] {
     .filter(Boolean)
     .join(' ');
   const methods = new Set<string>();
-  const methodPattern = HTTP_METHODS.join('|');
-  const directExportPattern = new RegExp(
-    `\bexport\s+(?:async\s+)?(?:function|const|let|var)\s+(${methodPattern})\b`,
-    'g'
-  );
-  const specifierExportPattern = /\bexport\s*{([^}]*)}/g;
 
-  let match = directExportPattern.exec(code);
-  while (match) {
-    methods.add(match[1] ?? '');
-    match = directExportPattern.exec(code);
-  }
   for (const method of HTTP_METHODS) {
     if (
       [
@@ -149,23 +138,6 @@ function getExportedMethods(source: string): string[] {
       methods.add(method);
     }
   }
-  match = specifierExportPattern.exec(code);
-  while (match) {
-    for (const specifier of match[1].split(',')) {
-      const exportedName = specifier
-        .trim()
-        .split(/\s+as\s+/)
-        .at(-1);
-      if (
-        exportedName &&
-        HTTP_METHODS.includes(exportedName as (typeof HTTP_METHODS)[number])
-      ) {
-        methods.add(exportedName);
-      }
-    }
-    match = specifierExportPattern.exec(code);
-  }
-
   let exportStart = code.indexOf('export {');
   while (exportStart !== -1) {
     const specifiersStart = exportStart + 'export {'.length;

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -99,7 +99,7 @@ function sanitizeSource(source: string): string {
       code += '\n';
     } else if (character === '/' && nextCharacter === '*') {
       const commentEnd = source.indexOf('*/', index + 2);
-      index = commentEnd === -1 ? source.length : commentEnd + 2;
+      index = commentEnd === -1 ? source.length : commentEnd + 1;
     } else if (character === "'" || character === '"' || character === '`') {
       const quote = character;
       index += 1;
@@ -117,7 +117,12 @@ function sanitizeSource(source: string): string {
 
 function getExportedMethods(source: string): string[] {
   const code = sanitizeSource(source);
-  const normalizedCode = code.replaceAll('\n', ' ').replaceAll('\t', ' ');
+  const normalizedCode = Array.from(code)
+    .map((character) => (character <= ' ' ? ' ' : character))
+    .join('')
+    .split(' ')
+    .filter(Boolean)
+    .join(' ');
   const methods = new Set<string>();
   const methodPattern = HTTP_METHODS.join('|');
   const directExportPattern = new RegExp(

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -1,0 +1,266 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const HTTP_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+
+export type ApiInfo = {
+  path: string;
+  methods: string[];
+};
+
+function isRouteFile(name: string): boolean {
+  return ['ts', 'tsx', 'js', 'jsx', 'mts', 'mtsx', 'mjs', 'mjsx'].includes(
+    name.startsWith('route.') ? name.slice('route.'.length) : ''
+  );
+}
+
+function getRouteFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return getRouteFiles(path);
+    }
+    return entry.isFile() && isRouteFile(entry.name) ? [path] : [];
+  });
+}
+
+function getApiSegments(apiFolder: string): string[] {
+  const normalizedFolder = apiFolder.split(/[\\/]/).filter(Boolean);
+  const appIndex = normalizedFolder.lastIndexOf('app');
+  const pagesIndex = normalizedFolder.lastIndexOf('pages');
+  const routeRootIndex = Math.max(appIndex, pagesIndex);
+
+  return routeRootIndex === -1
+    ? [normalizedFolder.at(-1) ?? 'api']
+    : normalizedFolder.slice(routeRootIndex + 1);
+}
+
+function toOpenApiSegment(segment: string): string {
+  if (segment.startsWith('[[...') && segment.endsWith(']]')) {
+    return `{${segment.slice(5, -2)}}`;
+  }
+  if (segment.startsWith('[...') && segment.endsWith(']')) {
+    return `{${segment.slice(4, -1)}}`;
+  }
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return `{${segment.slice(1, -1)}}`;
+  }
+  return segment;
+}
+
+function toOpenApiPaths(segments: string[]): string[] {
+  const isOptionalCatchAll = (segment: string) =>
+    segment.startsWith('[[...') && segment.endsWith(']]');
+  const pathSegments = segments.filter(
+    (segment) =>
+      !(segment.startsWith('(') && segment.endsWith(')')) &&
+      !segment.startsWith('@')
+  );
+  const optionalCatchAllIndex = pathSegments.findIndex(isOptionalCatchAll);
+  const paths = (
+    optionalCatchAllIndex === -1
+      ? [pathSegments]
+      : [
+          pathSegments.filter((_, index) => index !== optionalCatchAllIndex),
+          pathSegments,
+        ]
+  ).map((path) =>
+    path.map((segment) =>
+      segment
+        .replace(/^\[\[\.\.\.(.+?)\]\]$/, '{$1}')
+        .replace(/^\[\.\.\.(.+?)\]$/, '{$1}')
+        .replace(/^\[(.+)\]$/, '{$1}')
+    )
+  );
+
+  return paths.map((path) => `/${path.map(toOpenApiSegment).join('/')}`);
+}
+
+function sanitizeSource(source: string): string {
+  let code = '';
+  let index = 0;
+
+  while (index < source.length) {
+    const character = source[index];
+    const nextCharacter = source[index + 1];
+    if (character === '/' && nextCharacter === '/') {
+      index = source.indexOf('\n', index);
+      if (index === -1) {
+        break;
+      }
+      code += '\n';
+    } else if (character === '/' && nextCharacter === '*') {
+      const commentEnd = source.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? source.length : commentEnd + 2;
+    } else if (character === "'" || character === '"' || character === '`') {
+      const quote = character;
+      index += 1;
+      while (index < source.length && source[index] !== quote) {
+        index += source[index] === '\\' ? 2 : 1;
+      }
+    } else {
+      code += character;
+    }
+    index += 1;
+  }
+
+  return code;
+}
+
+function getExportedMethods(source: string): string[] {
+  const code = sanitizeSource(source);
+  const normalizedCode = code.replaceAll('\n', ' ').replaceAll('\t', ' ');
+  const methods = new Set<string>();
+  const methodPattern = HTTP_METHODS.join('|');
+  const directExportPattern = new RegExp(
+    `\bexport\s+(?:async\s+)?(?:function|const|let|var)\s+(${methodPattern})\b`,
+    'g'
+  );
+  const specifierExportPattern = /\bexport\s*{([^}]*)}/g;
+
+  let match = directExportPattern.exec(code);
+  while (match) {
+    methods.add(match[1] ?? '');
+    match = directExportPattern.exec(code);
+  }
+  for (const method of HTTP_METHODS) {
+    if (
+      [
+        `export function ${method}`,
+        `export async function ${method}`,
+        `export const ${method}`,
+        `export let ${method}`,
+        `export var ${method}`,
+      ].some((declaration) => normalizedCode.includes(declaration))
+    ) {
+      methods.add(method);
+    }
+  }
+  match = specifierExportPattern.exec(code);
+  while (match) {
+    for (const specifier of match[1].split(',')) {
+      const exportedName = specifier
+        .trim()
+        .split(/\s+as\s+/)
+        .at(-1);
+      if (
+        exportedName &&
+        HTTP_METHODS.includes(exportedName as (typeof HTTP_METHODS)[number])
+      ) {
+        methods.add(exportedName);
+      }
+    }
+    match = specifierExportPattern.exec(code);
+  }
+
+  let exportStart = code.indexOf('export {');
+  while (exportStart !== -1) {
+    const specifiersStart = exportStart + 'export {'.length;
+    const specifiersEnd = code.indexOf('}', specifiersStart);
+    if (specifiersEnd === -1) {
+      break;
+    }
+    for (const specifier of code
+      .slice(specifiersStart, specifiersEnd)
+      .split(',')) {
+      const exportedName = specifier.trim().split(' as ').at(-1);
+      if (
+        exportedName &&
+        HTTP_METHODS.includes(exportedName as (typeof HTTP_METHODS)[number])
+      ) {
+        methods.add(exportedName);
+      }
+    }
+    exportStart = code.indexOf('export {', specifiersEnd);
+  }
+
+  return HTTP_METHODS.filter((method) => methods.has(method)).map((method) =>
+    method.toLowerCase()
+  );
+}
+
+/** Extract App Router API paths and exported HTTP methods from route files. */
+export function extractApiInfo(
+  apiFolder: string,
+  cwd = process.cwd()
+): ApiInfo[] {
+  const directories = [
+    join(cwd, apiFolder),
+    join(cwd, '.next/server', apiFolder),
+  ].filter(existsSync);
+  const apiInfos = new Map<string, Set<string>>();
+
+  for (const apiDirectory of directories) {
+    for (const file of getRouteFiles(apiDirectory)) {
+      const routeSegments = relative(apiDirectory, file)
+        .split(sep)
+        .slice(0, -1);
+      const methods = getExportedMethods(readFileSync(file, 'utf8'));
+      for (const path of toOpenApiPaths([
+        ...getApiSegments(apiFolder),
+        ...routeSegments,
+      ])) {
+        const pathMethods = apiInfos.get(path) ?? new Set<string>();
+        methods.forEach((method) => pathMethods.add(method));
+        apiInfos.set(path, pathMethods);
+      }
+    }
+  }
+
+  return Array.from(apiInfos.entries())
+    .map(([path, methods]) => ({
+      path,
+      methods: HTTP_METHODS.filter((method) =>
+        methods.has(method.toLowerCase())
+      ).map((method) => method.toLowerCase()),
+    }))
+    .filter((api) => api.methods.length > 0);
+}
+
+export function generateAutoDoc(apiInfos: ApiInfo[]) {
+  return Object.fromEntries(
+    apiInfos.map(({ path, methods }) => [
+      path,
+      {
+        ...Object.fromEntries(
+          methods.map((method) => [
+            method,
+            {
+              summary: `${method.toUpperCase()} ${path}`,
+              parameters: getPathParameters(path),
+              responses: {
+                200: { description: 'Successful response' },
+              },
+            },
+          ])
+        ),
+      },
+    ])
+  );
+}
+
+function getPathParameters(path: string) {
+  const parameters = [];
+  const parameterPattern = /\{(.+?)}/g;
+  let match = parameterPattern.exec(path);
+
+  while (match) {
+    parameters.push({
+      name: match[1],
+      in: 'path' as const,
+      required: true,
+      schema: { type: 'string' },
+    });
+    match = parameterPattern.exec(path);
+  }
+
+  return parameters;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export * from './auto-doc';
 export * from './swagger';

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -124,7 +124,12 @@ export function withSwagger({
       });
       res.status(200).send(swaggerSpec);
     } catch (error) {
-      res.status(400).send(error);
+      res.status(400).json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to create Swagger spec',
+      });
     }
   };
 }

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,12 +1,19 @@
 import { join } from 'node:path';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import swaggerJsdoc, { type OAS3Definition, type Options } from 'swagger-jsdoc';
+import { extractApiInfo, generateAutoDoc } from './auto-doc';
+
+export type AutoDocOptions = {
+  enabled?: boolean;
+};
 
 export type SwaggerOptions = Options & {
   apiFolder?: string;
   schemaFolders?: string[];
   definition: OAS3Definition;
   outputFile?: string;
+  /** Generate basic OpenAPI operations from App Router route files. */
+  autoDoc?: boolean | AutoDocOptions;
 };
 
 const defaultOptions: SwaggerOptions = {
@@ -33,6 +40,7 @@ const defaultOptions: SwaggerOptions = {
 export function createSwaggerSpec({
   apiFolder = 'pages/api',
   schemaFolders = [],
+  autoDoc = false,
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   const scanFolders = [apiFolder, ...schemaFolders];
@@ -74,7 +82,19 @@ export function createSwaggerSpec({
     ...swaggerOptions,
     definition,
   };
-  const spec = swaggerJsdoc(options);
+  const spec = swaggerJsdoc(options) as OAS3Definition;
+
+  if (autoDoc === true || (typeof autoDoc === 'object' && autoDoc.enabled)) {
+    const autoPaths = generateAutoDoc(extractApiInfo(apiFolder));
+    spec.paths = Object.fromEntries(
+      Object.entries({ ...autoPaths, ...spec.paths }).map(
+        ([path, operations]) => {
+          const generatedOperations = autoPaths[path] ?? {};
+          return [path, { ...generatedOperations, ...operations }];
+        }
+      )
+    );
+  }
 
   return spec;
 }
@@ -91,6 +111,7 @@ export function createSwaggerSpec({
 export function withSwagger({
   apiFolder = 'pages/api',
   schemaFolders = [],
+  autoDoc = false,
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   return () => (_req: NextApiRequest, res: NextApiResponse) => {
@@ -98,6 +119,7 @@ export function withSwagger({
       const swaggerSpec = createSwaggerSpec({
         apiFolder,
         schemaFolders,
+        autoDoc,
         ...swaggerOptions,
       });
       res.status(200).send(swaggerSpec);

--- a/test/fixtures/.next/server/app/api/compiled/route.js
+++ b/test/fixtures/.next/server/app/api/compiled/route.js
@@ -1,0 +1,3 @@
+export function OPTIONS() {
+  return new Response();
+}

--- a/test/fixtures/.next/server/app/only-compiled/compiled/route.js
+++ b/test/fixtures/.next/server/app/only-compiled/compiled/route.js
@@ -1,0 +1,3 @@
+export function OPTIONS() {
+  return new Response();
+}

--- a/test/fixtures/app/api/health/route.ts
+++ b/test/fixtures/app/api/health/route.ts
@@ -1,0 +1,7 @@
+export function GET() {
+  return Response.json({ status: 'ok' });
+}
+
+export async function HEAD() {
+  return new Response(null);
+}

--- a/test/fixtures/app/api/manual/route.ts
+++ b/test/fixtures/app/api/manual/route.ts
@@ -1,0 +1,12 @@
+/**
+ * @swagger
+ * /api/manual:
+ *   get:
+ *     summary: Manual documentation
+ *     responses:
+ *       204:
+ *         description: No content
+ */
+export function GET() {
+  return new Response(null, { status: 204 });
+}

--- a/test/fixtures/app/api/users/[id]/route.ts
+++ b/test/fixtures/app/api/users/[id]/route.ts
@@ -1,0 +1,3 @@
+export const PATCH = async () => Response.json({});
+
+export const DELETE = async () => new Response(null, { status: 204 });

--- a/test/fixtures/app/blog/[[...slug]]/route.ts
+++ b/test/fixtures/app/blog/[[...slug]]/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response();
+}

--- a/test/fixtures/app/commented/route.ts
+++ b/test/fixtures/app/commented/route.ts
@@ -1,0 +1,3 @@
+export /* This handler is public. */ function GET() {
+  return new Response();
+}

--- a/test/fixtures/app/users/route.ts
+++ b/test/fixtures/app/users/route.ts
@@ -1,0 +1,6 @@
+// export function DELETE() {}
+const string = 'export function DELETE() {}';
+
+const handler = () => new Response(string);
+
+export { handler as GET, handler as POST };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -97,6 +97,7 @@ describe('withSwagger', () => {
       { path: '/api/users/{id}', methods: ['patch', 'delete'] },
       { path: '/blog', methods: ['get'] },
       { path: '/blog/{slug}', methods: ['get'] },
+      { path: '/commented', methods: ['get'] },
       { path: '/users', methods: ['get', 'post'] },
     ]);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createSwaggerSpec } from '../src';
+import { createSwaggerSpec, extractApiInfo } from '../src';
 
 describe('withSwagger', () => {
   it('should create default swagger json option', () => {
@@ -88,5 +88,72 @@ describe('withSwagger', () => {
         apiFolder: 'pages/api',
       })
     ).toMatchSnapshot();
+  });
+
+  it('extracts App Router paths and exported HTTP methods', () => {
+    expect(extractApiInfo('test/fixtures/app')).toEqual([
+      { path: '/api/health', methods: ['get', 'head'] },
+      { path: '/api/manual', methods: ['get'] },
+      { path: '/api/users/{id}', methods: ['patch', 'delete'] },
+      { path: '/blog', methods: ['get'] },
+      { path: '/blog/{slug}', methods: ['get'] },
+      { path: '/users', methods: ['get', 'post'] },
+    ]);
+  });
+
+  it('extracts compiled routes when source files are unavailable', () => {
+    expect(extractApiInfo('app/only-compiled', 'test/fixtures')).toEqual([
+      { path: '/only-compiled/compiled', methods: ['options'] },
+    ]);
+  });
+
+  it('generates basic documentation without replacing manual operations', () => {
+    const spec = createSwaggerSpec({
+      apiFolder: 'test/fixtures/app/api',
+      autoDoc: true,
+      definition: {
+        openapi: '3.0.0',
+        info: { title: 'Auto docs', version: '1.0.0' },
+      },
+    });
+
+    expect(spec.paths).toMatchObject({
+      '/api/health': {
+        get: { responses: { 200: { description: 'Successful response' } } },
+        head: { responses: { 200: { description: 'Successful response' } } },
+      },
+      '/api/manual': {
+        get: {
+          summary: 'Manual documentation',
+          responses: { 204: { description: 'No content' } },
+        },
+      },
+      '/api/users/{id}': {
+        patch: {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+          responses: { 200: { description: 'Successful response' } },
+        },
+        delete: { responses: { 200: { description: 'Successful response' } } },
+      },
+    });
+  });
+
+  it('extracts a narrowed API folder', () => {
+    expect(extractApiInfo('test/fixtures/app/api')).toEqual([
+      { path: '/api/health', methods: ['get', 'head'] },
+      { path: '/api/manual', methods: ['get'] },
+      { path: '/api/users/{id}', methods: ['patch', 'delete'] },
+    ]);
+  });
+
+  it('ignores a missing App Router directory', () => {
+    expect(extractApiInfo('test/fixtures/missing')).toEqual([]);
   });
 });


### PR DESCRIPTION
## What
- Add opt-in `autoDoc` support for automatically generating basic OpenAPI operations from App Router `route.*` files.
- Detect exported HTTP handlers, route groups, dynamic segments, catch-all routes, and optional catch-all routes.
- Scan both source routes and `.next/server` output, with manual `@swagger` operations taking precedence.

## Why
Issue #809 asks consumers to avoid duplicating API paths and HTTP methods in JSDoc when Next.js already provides that information through route structure and exports.

## How
- Added the route scanner and OpenAPI operation generator in `src/auto-doc.ts`.
- Integrated it into `createSwaggerSpec` and `withSwagger` behind `autoDoc: true`.
- Added fixture-driven coverage for App Router routes, dynamic and optional catch-all paths, export aliases, comments/strings, compiled-only routes, and manual-operation precedence.
- Documented the option in the README.

## Verification
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic OpenAPI documentation generation for App Router API routes.
  * Detects route paths, HTTP methods, dynamic parameters, and successful response metadata.
  * Supports dynamic, catch-all, optional catch-all, grouped, and parallel route segments.
  * Combines routes from source files and compiled output.
  * Preserves manually defined Swagger operations over generated documentation.
  * Added `autoDoc` configuration support and structured JSON error responses.

* **Documentation**
  * Added setup guidance and configuration examples for automatic documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->