### PR TITLE
feat: deepen route-source parser with es-module-lexer

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# ARCHITECTURE — next-swagger-doc
+
+## Overview
+
+A small, dependency-light library with **three public surfaces**:
+
+1. `createSwaggerSpec()` — build an OpenAPI 3 spec object from JSDoc-annotated route files
+2. `withSwagger()` — Next.js API-route middleware that serves the spec as JSON
+3. `next-swagger-doc-cli` — CLI that reads a JSON config and writes `swagger.json`
+
+Plus a newer **App Router auto-doc** feature that derives basic operations from `route.ts` files without any annotations.
+
+## Layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Entry: src/index.ts (re-exports public API)                │
+├─────────────────────────────────────────────────────────────┤
+│  src/swagger.ts     — spec creation + Next.js middleware    │
+│  src/auto-doc.ts    — App Router route scanner + generator  │
+│  src/route-parser.ts — route source parsing (es-module-lexer) │
+│  src/cli.ts         — CLI binary (cleye)                    │
+├─────────────────────────────────────────────────────────────┤
+│  swagger-jsdoc    — parses JSDoc annotations → OAS3 spec    │
+│  node:fs / node:path — filesystem scanning                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Core Modules
+
+### `src/swagger.ts` — public API
+
+- **`SwaggerOptions`** = swagger-jsdoc `Options` + `apiFolder` (default `'pages/api'`), `schemaFolders` (default `[]`), `definition` (required `OAS3Definition`), `outputFile`, `autoDoc` (`boolean | AutoDocOptions`)
+- **`createSwaggerSpec()`**
+  1. Builds a glob list of `apis` from `apiFolder` + `schemaFolders`, scanning three locations: source dir (`**/*.{ts,tsx,jsx,js,json,swagger.yaml}`), `.next/server` build dir (js/swagger.yaml/json only), and `public/` (swagger.yaml/json)
+  2. Injects a `servers` entry from `process.env.__NEXT_ROUTER_BASEPATH` if a base path is set and no `servers` are defined
+  3. Delegates to `swaggerJsdoc(options)` for the base spec
+  4. If `autoDoc` is enabled, merges generated paths from `generateAutoDoc(extractApiInfo(apiFolder))` into `spec.paths` — **manual `@swagger` operations win** over generated ones
+- **`withSwagger()`** — returns a Next.js API handler; wraps `createSwaggerSpec` in try/catch, sends `200` + spec or `400` + `{ error }`
+
+### `src/auto-doc.ts` — App Router scanner (newest feature)
+
+- **`extractApiInfo(apiFolder, cwd)`** — walks the folder recursively, finds `route.*` files (ts/tsx/js/jsx/mts/mtsx/mjs/mjsx), reads exported HTTP methods, converts directory segments to OpenAPI path segments, and returns sorted `{ path, methods }[]`. Scans both the source folder and `.next/server/<apiFolder>` (compiled `route.js` files) when present.
+- **`generateAutoDoc(apiInfos)`** — builds minimal operations: `summary` (`"GET /path"`), path `parameters` from `{...}` segments, and a default `200` "Successful response".
+- **Internal helpers**:
+  - `getRouteFiles()` — recursive directory walk
+  - `getApiSegments()` — strips everything up to the `app`/`pages` root to derive the API base path
+  - `toOpenApiPaths()` — converts `[id]` → `{id}`, `[...slug]` → `{slug}`, `[[...slug]]` → optional catch-all (emits both with and without the segment), drops route groups `(…)` and `@` parallel-route segments
+  - `getPathParameters()` — regex-extracts `{param}` from a path
+
+### `src/route-parser.ts` — route source parser
+
+- **`getExportedMethods(source)`** — extracts exported HTTP method handler names from a route module's source using **es-module-lexer** (`initSync` + `parse`). Handles comments, strings, and regex literals correctly; a per-file parse failure warns and returns `[]` rather than crashing doc generation.
+- **`HTTP_METHODS`** — the ordered list of HTTP methods a route can export (shared with `auto-doc.ts`).
+
+### `src/cli.ts` — CLI
+
+- Uses `cleye` to parse `<config file>` (required positional) and `--output` (default `public/swagger.json`)
+- Reads the JSON config, calls `createSwaggerSpec`, writes pretty-printed JSON
+
+## Data Flow
+
+**Manual (JSDoc) path:**
+```
+route files with @swagger comments ──► swagger-jsdoc ──► spec.paths (from annotations)
+```
+
+**Auto-doc path:**
+```
+route.ts files ──► extractApiInfo (paths + methods)
+            ──► generateAutoDoc (basic operations)
+            ──► merged into spec.paths (manual overrides generated)
+```
+
+**Runtime serving:**
+```
+createSwaggerSpec ──► withSwagger handler ──► GET /api/doc → JSON spec
+```
+
+## Key Design Decisions
+
+- **Real lexer over string matching** — auto-doc extracts exported handlers with es-module-lexer (a real ESM lexer) instead of the previous hand-rolled string scanner; comments, strings, and regex literals no longer cause false positives or misses
+- **Dual source + build-dir scanning** — supports both dev (source) and production (`.next/server` compiled) scenarios
+- **Manual-over-generated precedence** — `{ ...generatedOperations, ...operations }` merge ensures hand-written docs are never clobbered
+- **Dual ESM/CJS output** via pkgroll with a single `src/` source of truth

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -30,12 +30,15 @@ Plus a newer **App Router auto-doc** feature that derives basic operations from 
 
 ### `src/swagger.ts` — public API
 
-- **`SwaggerOptions`** = swagger-jsdoc `Options` + `apiFolder` (default `'pages/api'`), `schemaFolders` (default `[]`), `definition` (required `OAS3Definition`), `outputFile`, `autoDoc` (`boolean | AutoDocOptions`)
+- **`SwaggerOptions`** = swagger-jsdoc `Options` + `apiFolder` (default `'pages/api'`), `schemaFolders` (default `[]`), `definition` (required `OAS3Definition`), `outputFile`, `specFile`, `scanBuildOutput`, `autoDoc` (`boolean | AutoDocOptions`)
 - **`createSwaggerSpec()`**
-  1. Builds a glob list of `apis` from `apiFolder` + `schemaFolders`, scanning three locations: source dir (`**/*.{ts,tsx,jsx,js,json,swagger.yaml}`), `.next/server` build dir (js/swagger.yaml/json only), and `public/` (swagger.yaml/json)
-  2. Injects a `servers` entry from `process.env.__NEXT_ROUTER_BASEPATH` if a base path is set and no `servers` are defined
-  3. Delegates to `swaggerJsdoc(options)` for the base spec
-  4. If `autoDoc` is enabled, merges generated paths from `generateAutoDoc(extractApiInfo(apiFolder))` into `spec.paths` — **manual `@swagger` operations win** over generated ones
+  1. If `specFile` exists, returns that JSON document (standalone build-time path)
+  2. Builds a glob list of `apis` from `apiFolder` + `schemaFolders`: source dir (`**/*.{ts,tsx,jsx,js,json,swagger.yaml}`), `public/` (swagger.yaml/json), and `.next/server` only when `shouldScanBuildDirectory` says so
+  3. Injects a `servers` entry from `process.env.__NEXT_ROUTER_BASEPATH` if a base path is set and no `servers` are defined
+  4. Delegates to `swaggerJsdoc(options)` for the base spec
+  5. If `isAutoDocEnabled` (explicit on, or source folder missing unless `autoDoc: false`), merges generated paths — **manual `@swagger` operations win**
+  6. Optionally writes `outputFile`
+- **`shouldScanBuildDirectory()`** — skips `.next` while `NEXT_PHASE` is a production build/export (Vercel `export-detail.json` ENOENT). Compiled output is a runtime fallback when source is gone, or when `scanBuildOutput: true`.
 - **`withSwagger()`** — returns a Next.js API handler; wraps `createSwaggerSpec` in try/catch, sends `200` + spec or `400` + `{ error }`
 
 ### `src/auto-doc.ts` — App Router scanner (newest feature)
@@ -80,6 +83,6 @@ createSwaggerSpec ──► withSwagger handler ──► GET /api/doc → JSON 
 ## Key Design Decisions
 
 - **Real lexer over string matching** — auto-doc extracts exported handlers with es-module-lexer (a real ESM lexer) instead of the previous hand-rolled string scanner; comments, strings, and regex literals no longer cause false positives or misses
-- **Dual source + build-dir scanning** — supports both dev (source) and production (`.next/server` compiled) scenarios
+- **Source first, compiled fallback** — do not glob `.next` during `next build`; scan compiled output only when the source folder is missing or `scanBuildOutput` is true
 - **Manual-over-generated precedence** — `{ ...generatedOperations, ...operations }` merge ensures hand-written docs are never clobbered
 - **Dual ESM/CJS output** via pkgroll with a single `src/` source of truth

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,42 @@
+# CONCERNS — next-swagger-doc
+
+## Parsing (previously the highest risk)
+
+- **Resolved**: the hand-rolled source scanner (`sanitizeSource()` + string matching in `getExportedMethods`) was replaced with **es-module-lexer** (`src/route-parser.ts`) — a real ESM lexer that handles comments, strings, and regex literals correctly. The old approach silently missed handlers when source contained regex literals with comment-like sequences; a regression fixture (`test/fixtures/app/api/regex/route.ts`) now guards this.
+- **Remaining**: `getApiSegments()` uses `lastIndexOf('app')` / `lastIndexOf('pages')` on the folder path — a folder named `myapp`, `pages2`, or a parent dir containing "app"/"pages" would be mis-split
+- **Regex-based path parameter extraction** (`getPathParameters`) — fine for simple `{id}` but won't handle path parameters with regex constraints or multi-segment patterns
+
+## Versioning / Release Hygiene
+
+- `package.json` is at **`0.4.2-0`** (prerelease) but `CHANGELOG.md` stops at **0.3.4 (2022)** — changelog is 4 minor versions behind
+- `.changes/unreleased/` is empty (only `.gitkeep`) — no change fragments for the new App Router feature (PR #1241) or any other unreleased work
+- `next-swagger-doc.txt` is a **cspell dictionary**, not documentation, despite the name
+
+## Config / Tooling Drift
+
+- `size-limit` is a devDependency but has **no config file** and no script — dead dependency
+- `tsconfig.json` includes a `types/` directory that **does not exist** (harmless, but stale)
+- `c8` and `@vitest/coverage-v8` both present (overlapping coverage tooling)
+- `.swm/testing-overview.b1r1n.sw.md` references **Playwright E2E tests that don't exist** in the repo — misleading onboarding doc
+- `examples/next15-app/package.json` is named `"next13-app"` (copy-paste from the older example)
+
+## CI Gaps
+
+- **No CI workflow runs tests or lint** — only CodeQL and CodeSee workflows exist; regressions are caught only by pre-commit hooks (which require local install) and local `pnpm test`
+- CodeQL runs on every push/PR but there's no coverage or typecheck gate
+
+## Potential Runtime Issues
+
+- `extractApiInfo()` scans **both** the source folder and `.next/server/<apiFolder>` and merges results into a single map — if a route exists in both (stale build output), methods could be double-counted or a stale compiled route could surface a method that no longer exists in source
+- `swagger.ts` globs `**/*.{ts,tsx,jsx,js,json,swagger.yaml}` across the api folder — large folders or non-route files (helpers, types) get fed to swagger-jsdoc and could produce unexpected spec entries
+- `withSwagger` returns `400` on failure but does **not log** the error — silent failures in production are hard to diagnose
+- Base-path injection relies on the internal `process.env.__NEXT_ROUTER_BASEPATH` env var (Next.js internals) — could change between Next versions
+
+## Security
+
+- No obvious vulnerabilities in the small codebase; CodeQL is configured. `noGlobalEval` is enforced. No user input is evaluated. The main risk surface is the parser being fed arbitrary source (low risk — the lexer never executes the code).
+
+## Performance
+
+- Trivial for typical API sizes. `extractApiInfo` does a full recursive directory walk and reads every route file synchronously (`readFileSync`) — fine for dev/docs generation, but the sync I/O could add up on very large route trees
+- `createSwaggerSpec` re-reads and re-parses everything on every call (no caching) — relevant if called per-request via `withSwagger` in production

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,65 @@
+# CONVENTIONS — next-swagger-doc
+
+## Code Style (enforced by Biome — `biome.json`)
+
+- **Indentation**: 2 spaces, LF line endings
+- **Quotes**: single quotes; double quotes for JSX
+- **Semicolons**: always
+- **Trailing commas**: es5 (objects/arrays, not function params)
+- **Line width**: 80
+- **Imports**: auto-organized (`organizeImports` enabled); type-only imports preferred (`useImportType`, `useExportType`)
+- **Arrow functions** preferred over function expressions (`useArrowFunction`); block statements required (`useBlockStatements`)
+
+## Lint Rules (curated, `recommended: false`)
+
+Biome is configured with explicit rule sets rather than the recommended preset:
+
+- **complexity**: no useless catch/constructor/ternary/type-constraint; `useOptionalChain`, `useRegexLiterals`, `useLiteralKeys`
+- **correctness**: no unused variables, no undeclared variables, `useIsNan`, no unsafe optional chaining
+- **security**: `noGlobalEval`
+- **style**: `noVar`, `useConst`, `useNamingConvention` (warn), `useAsConstAssertion`, `useExponentiationOperator`, restricted globals (`event`, `atob`, `btoa`)
+- **suspicious**: `noDebugger`, `noDoubleEquals`, `noPrototypeBuiltins`, `noRedeclare`, `useValidTypeof`, etc.
+- `dist/` and `.eslintrc.cjs`/`vite.config.ts` are ignored; `.d.ts` files relax `noUnusedVariables`
+
+## TypeScript Conventions
+
+- **Strict mode** (`strict: true`) plus `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`
+- `moduleResolution: node`, `esModuleInterop`, `skipLibCheck`, `forceConsistentCasingInFileNames`
+- `importHelpers: true` (tslib)
+- Type-only imports via `import type { … }` (e.g. `import type { NextApiRequest, NextApiResponse } from 'next'`)
+- `as const` for literal tuples (`HTTP_METHODS`)
+- No default exports in library code; named exports only
+
+## Naming
+
+- Functions: `camelCase`, action-first (`createSwaggerSpec`, `extractApiInfo`, `getRouteFiles`)
+- Types: `PascalCase` (`SwaggerOptions`, `ApiInfo`, `AutoDocOptions`)
+- Constants: `UPPER_SNAKE_CASE` (`HTTP_METHODS`, `defaultOptions`)
+- Private helpers are module-local (not exported)
+
+## Patterns
+
+- **Default parameters** for options (`apiFolder = 'pages/api'`, `autoDoc = false`)
+- **Destructuring** options in function signatures, spreading the rest into swagger-jsdoc options
+- **Functional style**: `flatMap`, `filter`, `map`, `Object.fromEntries`; `Set`/`Map` for dedup (`apiInfos` map, `methods` set)
+- **JSDoc comments** on public API functions (`createSwaggerSpec`, `withSwagger`) describing params and returns
+- **No TODO/FIXME/HACK comments** anywhere in the codebase (verified via search)
+
+## Error Handling
+
+- `withSwagger` wraps spec creation in try/catch: success → `res.status(200).send(spec)`; failure → `res.status(400).json({ error })` with a fallback message `'Failed to create Swagger spec'`
+- Error message extraction uses `error instanceof Error ? error.message : fallback`
+- No custom error classes; logging is limited to a `console.warn` in `route-parser.ts` when a route file fails to parse
+
+## Module & File Conventions
+
+- ESM (`"type": "module"`), Node built-ins imported explicitly (`node:fs`, `node:path`)
+- Single responsibility per file (swagger = API, auto-doc = scanner, route-parser = parser, cli = CLI)
+- `src/index.ts` is a pure barrel re-export
+
+## Commit / Release Conventions
+
+- Conventional-ish commit messages (`feat:`, `chore:`, `fix:`)
+- Changelog via Changie fragments in `.changes/unreleased/`
+- Renovate auto-merges non-major dependency updates
+- Pre-commit hooks: Prettier (html/css/markdown) + Biome check

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,46 @@
+# INTEGRATIONS — next-swagger-doc
+
+This is a **library**, not a service-backed app. It has no database, no auth provider, no external API calls, and no webhooks at runtime. Integrations are limited to the libraries it builds on and the tooling around the repo.
+
+## Core Library Integrations
+
+| Integration | Type | How it's used |
+| --- | --- | --- |
+| **swagger-jsdoc** (`src/swagger.ts`) | npm library | Parses `@swagger` JSDoc annotations from route files and merges them with the OpenAPI `definition` into a spec object. This is the entire "engine" of the library. |
+| **Next.js** (`src/swagger.ts`) | peer framework | `NextApiRequest`/`NextApiResponse` types for `withSwagger` middleware; scans `.next/server` build output; reads `__NEXT_ROUTER_BASEPATH` env for base-path-aware servers. |
+| **cleye** (`src/cli.ts`) | npm library | CLI flag/parameter parsing for the `next-swagger-doc-cli` binary. |
+| **es-module-lexer** (`src/route-parser.ts`) | npm library | Real ESM lexer that extracts exported names from route source, replacing the hand-rolled string scanner in auto-doc. |
+
+## Build / Docs / Quality Tooling
+
+| Integration | Purpose |
+| --- | --- |
+| **pkgroll** | Bundling to dual ESM/CJS output |
+| **typedoc** | Generates API reference docs (used in `vercel-build`) |
+| **Biome** | Lint + format |
+| **Vitest** | Unit testing |
+| **Renovate** (`renovate.json`) | Automated dependency PRs; auto-merges non-major bumps |
+| **pre-commit** (`.pre-commit-config.yaml`) | Prettier + Biome hooks |
+| **Changie** (`.changie.yaml`, `.changes/`) | Changelog fragment management |
+| **cspell** | Spell checking |
+| **all-contributors-cli** | Contributor badge/table in README |
+
+## CI / SaaS
+
+| Integration | Location | Purpose |
+| --- | --- | --- |
+| **GitHub Actions — CodeQL** | `.github/workflows/codeql-analysis.yml` | Security scanning (JavaScript), on push/PR to `main` + weekly schedule |
+| **GitHub Actions — CodeSee** | `.github/workflows/codesee-arch-diagram.yml` | Architecture diagram (uses `CODESEE_ARCH_DIAG_API_TOKEN` secret) |
+| **GitHub Sponsors / Ko-fi** | `.github/FUNDING.yml` | Funding links |
+
+> Note: there is **no** CI workflow for running tests or lint — those run only locally/pre-commit.
+
+## Example App Integrations (not part of the library)
+
+- `swagger-ui-react` — renders the generated spec as Swagger UI in `examples/next14-app` and `examples/next15-app`
+- `next-themes`, `tailwindcss`, `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`, `@radix-ui/react-slot`, `sharp` — UI stack of the example apps
+- `openapi-types` — OpenAPI type helpers in examples
+
+## Auth / Security Schemes (documented, not connected)
+
+The library and examples document OpenAPI security schemes (Bearer JWT, OAuth2) in the generated spec — these are **documentation only**; no authentication is enforced or integrated.

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,77 @@
+# STACK — next-swagger-doc
+
+> Library that generates Swagger/OpenAPI JSON from Next.js API routes. Published on npm as `next-swagger-doc`, MIT licensed, maintained by Huynh Duc Dung (jellydn).
+
+## Languages & Runtime
+
+- **TypeScript** 5.8.3 — all source in `src/` (`tsconfig.json`)
+- **Node.js** >= 18 (`package.json` `engines`, `.nvmrc` pins `lts/*`)
+- **ESM-first** — `"type": "module"`; ships both ESM (`dist/index.js`) and CJS (`dist/index.cjs`) bundles
+
+## Package Manager
+
+- **pnpm** 10.9.0 (`packageManager` field, `pnpm-lock.yaml`)
+
+## Build & Tooling
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| pkgroll | 2.12.1 | Bundler — `pnpm build` / `pnpm start --watch`; emits `dist/index.cjs`, `dist/index.js`, `dist/index.d.ts`, `dist/cli.js` |
+| TypeScript | 5.8.3 | Type checking (`tsconfig.json`, strict) |
+| Biome | 1.9.4 | Lint + format (`biome.json`, `pnpm lint`, `pnpm format`) |
+| Vitest | 3.1.2 | Unit tests (`vitest.config.ts`, `pnpm test`) |
+| typedoc | 0.28.3 | API docs (`pnpm vercel-build` runs `typedoc src/index.ts`) |
+| size-limit | 11.2.0 | Declared devDependency — **no config file found** (unused) |
+| c8 / @vitest/coverage-v8 | 10.1.3 / 3.1.2 | Coverage (`pnpm coverage`) |
+
+## Runtime Dependencies
+
+| Package | Version | Role |
+| --- | --- | --- |
+| swagger-jsdoc | 6.2.8 | Core engine — parses JSDoc `@swagger` annotations into an OAS3 spec |
+| cleye | 1.3.4 | CLI argument parsing (`src/cli.ts`) |
+| es-module-lexer | 2.3.2 | Real ESM lexer — extracts exported HTTP handlers from route source (`src/route-parser.ts`) |
+| isarray | 2.0.5 | Array check helper |
+| @types/swagger-jsdoc | 6.0.4 | Types for swagger-jsdoc |
+
+## Peer Dependency
+
+- **next** >= 9 — the library targets Next.js API routes (pages router and App Router)
+
+## Dev Dependencies (notable)
+
+- `next` 15.3.1 (used by tests/examples), `@types/node` 22.14.1, `all-contributors-cli`, `sort-package-json`, `@vitest/ui`, `tslib`
+
+## Configuration Files
+
+| File | Purpose |
+| --- | --- |
+| `tsconfig.json` | Strict TS config; `noEmit`, declaration + sourceMap output via pkgroll |
+| `biome.json` | Lint rules (recommended off, curated rule sets) + formatter (2-space, single quotes, 80 cols) |
+| `vitest.config.ts` | Test config — `globals: true` |
+| `.nvmrc` | Node `lts/*` |
+| `renovate.json` | Dependency updates — auto-merge non-major, lockfile maintenance |
+| `cspell.json` + `cspell-tool.txt` | Spell-check dictionary |
+| `.pre-commit-config.yaml` | Prettier (html/css/markdown) + Biome pre-commit hooks |
+| `.changie.yaml` | Changelog generation (fragments in `.changes/`) |
+| `.gitignore` | Ignores `node_modules`, `dist`, `coverage`, `docs`, `.vercel` |
+
+## Package Entry Points
+
+- `exports`: `require` → `dist/index.cjs`, `import` → `dist/index.js`
+- `types`/`typings` → `dist/index.d.ts`
+- `bin`: `next-swagger-doc-cli` → `dist/cli.js`
+- Published files: `dist` + `src`
+
+## Scripts
+
+| Script | Command |
+| --- | --- |
+| `build` / `prepare` | `pkgroll` |
+| `start` | `pkgroll --watch` |
+| `test` | `vitest run` |
+| `test:ui` | `vitest --ui` |
+| `coverage` | `vitest run --coverage` |
+| `lint` | `biome lint src` |
+| `format` | `biome format src` |
+| `vercel-build` | `npx typedoc src/index.ts` |

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,69 @@
+# STRUCTURE — next-swagger-doc
+
+## Directory Layout
+
+```
+.
+├── src/                        # Library source (TypeScript, ESM)
+│   ├── index.ts                # Public entry — re-exports auto-doc + swagger
+│   ├── swagger.ts              # createSwaggerSpec, withSwagger, SwaggerOptions
+│   ├── auto-doc.ts             # extractApiInfo, generateAutoDoc (App Router)
+│   ├── route-parser.ts         # getExportedMethods via es-module-lexer
+│   └── cli.ts                  # next-swagger-doc-cli binary (cleye)
+├── test/
+│   ├── index.test.ts           # All unit tests (Vitest)
+│   ├── __snapshots__/          # Vitest snapshots for spec generation
+│   └── fixtures/               # Test fixtures
+│       ├── app/                # App Router route fixtures (route.ts files)
+│       │   ├── api/{health,manual,regex,users/[id],users}/
+│       │   ├── blog/[[...slug]]/
+│       │   ├── users/
+│       │   └── commented/
+│       └── .next/server/app/   # Compiled route.js fixtures (build-dir scanning)
+│           ├── only-compiled/compiled/route.js
+│           └── api/compiled/route.js
+├── examples/                   # Runnable demo apps (not published)
+│   ├── next13-simple/          # Pages Router demo (pages/api, models/, CLI config)
+│   ├── next14-app/             # App Router demo (app/api, app/api-doc, swagger-ui-react)
+│   └── next15-app/             # App Router demo (same shape as next14-app, Next 15 + React 19)
+├── .github/
+│   ├── workflows/              # codeql-analysis.yml, codesee-arch-diagram.yml
+│   └── FUNDING.yml
+├── .changes/                   # Changie changelog fragments (unreleased/)
+├── .swm/                       # Swimm docs (testing-overview, dev-environment-setup)
+├── .agents/                    # Agent config files (setup, resume)
+└── Root config files           # package.json, tsconfig.json, biome.json, vitest.config.ts,
+                                # renovate.json, cspell.json, .pre-commit-config.yaml,
+                                # .changie.yaml, .nvmrc, .gitignore
+```
+
+## Key Locations
+
+| Location | What lives there |
+| --- | --- |
+| `src/index.ts` | Public API surface (barrel) |
+| `src/swagger.ts` | Main spec-generation logic + Next middleware |
+| `src/auto-doc.ts` | App Router auto-documentation feature |
+| `src/route-parser.ts` | Route source parser (es-module-lexer) |
+| `src/cli.ts` | CLI entry (`bin` target) |
+| `test/fixtures/` | Route files used to test extraction/generation |
+| `examples/` | Three standalone Next.js apps demonstrating usage |
+
+## Naming Conventions
+
+- **Files**: `kebab-case` for source/config (`auto-doc.ts`, `next-swagger-doc.json`); `route.ts` / `page.tsx` per Next.js conventions inside examples
+- **Functions**: `camelCase`, verb-first for actions (`extractApiInfo`, `generateAutoDoc`, `createSwaggerSpec`, `getRouteFiles`)
+- **Types/Interfaces**: `PascalCase` (`ApiInfo`, `SwaggerOptions`, `AutoDocOptions`)
+- **Constants**: `UPPER_SNAKE_CASE` (`HTTP_METHODS`, `defaultOptions`)
+- **Exports**: named exports throughout; no default exports in the library (`src/`)
+- **Tests**: single `index.test.ts` with `describe('withSwagger', …)` suites; fixtures mirror real Next.js app structure
+
+## Entry Points
+
+- **Library**: `src/index.ts` → `dist/index.js` (ESM) / `dist/index.cjs` (CJS), types `dist/index.d.ts`
+- **CLI**: `src/cli.ts` → `dist/cli.js` (`next-swagger-doc-cli`)
+- **Docs**: `typedoc src/index.ts` (via `vercel-build`)
+
+## Generated / Ignored
+
+`dist/`, `node_modules/`, `coverage/`, `docs/`, `.vercel/` are gitignored. `tsconfig.tsbuildinfo` appears inside examples (not ignored there).

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,52 @@
+# TESTING — next-swagger-doc
+
+## Framework
+
+- **Vitest** 3.1.2, configured in `vitest.config.ts` with `globals: true` (describe/it/expect available globally)
+- Run with `pnpm test` (`vitest run`); UI mode via `pnpm test:ui`; coverage via `pnpm coverage` (`@vitest/coverage-v8`)
+
+## Test Layout
+
+- **Single test file**: `test/index.test.ts`
+- **Suites**: `describe('withSwagger', …)` containing all `it(...)` cases
+- **Snapshots**: `test/__snapshots__/index.test.ts.snap` (Vitest snapshot v1 format)
+- **Fixtures**: `test/fixtures/` mirrors real Next.js app structure:
+  - `app/**/route.ts` — source route files (App Router)
+  - `app/api/regex/route.ts` — route with a regex literal containing a comment-like sequence (regression fixture)
+  - `.next/server/app/**/route.js` — compiled route files (build-dir scanning)
+
+## What Is Tested
+
+1. **Default spec generation** — `createSwaggerSpec` with a minimal definition → snapshot
+2. **Bearer auth** — `securitySchemes.bearerAuth` → snapshot
+3. **OAuth2 auth** — `securitySchemes.OAuth2` with flows → snapshot
+4. **App Router path/method extraction** — `extractApiInfo('test/fixtures/app')` returns exact sorted `{ path, methods }[]`, covering:
+   - static routes (`/api/health` → get, head; `/users` → get, post)
+   - dynamic segments (`/api/users/{id}` → patch, delete)
+   - optional catch-all (`/blog` + `/blog/{slug}`)
+   - `export { handler as GET, handler as POST }` re-export syntax
+   - commented-out handlers and strings containing `export function DELETE` (comment/string handling)
+   - regex literals containing comment-like sequences (`/api/regex` → get) — the case that broke the old hand-rolled scanner
+5. **Compiled-route scanning** — `extractApiInfo('app/only-compiled', 'test/fixtures')` reads `.next/server` `route.js` when source is absent
+6. **Auto-doc generation** — `autoDoc: true` produces default `200` responses; manual `@swagger` operations are **not** replaced
+7. **Narrowed folders** — `extractApiInfo('test/fixtures/app/api')` scopes to a subfolder
+8. **Missing directories** — `extractApiInfo('test/fixtures/missing')` returns `[]`
+
+## Patterns
+
+- **Snapshot testing** is the primary assertion style for spec output (`toMatchSnapshot`)
+- **Exact-equality assertions** (`toEqual`) for extraction results
+- **`toMatchObject`** for partial spec assertions (auto-doc merge test)
+- No mocking framework in use — tests are pure/functional against real filesystem fixtures
+- No test helpers or shared setup; each test is self-contained
+
+## Coverage
+
+- Coverage tooling present (`@vitest/coverage-v8`, `c8`), but no coverage thresholds configured and no coverage CI gate
+
+## Gaps / Notes
+
+- `.swm/testing-overview.b1r1n.sw.md` (Swimm doc) claims Playwright E2E tests exist — **no Playwright config or E2E tests are present in the repo** (stale doc)
+- No CI workflow runs the test suite (only CodeQL + CodeSee workflows exist)
+- No tests for the CLI (`src/cli.ts`) or for `withSwagger`'s error path
+- `src/swagger.ts` base-path injection (`__NEXT_ROUTER_BASEPATH`) is untested

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@types/swagger-jsdoc": "6.0.4",
     "cleye": "1.3.4",
-    "es-module-lexer": "^2.3.2",
+    "es-module-lexer": "2.3.2",
     "isarray": "2.0.5",
     "swagger-jsdoc": "6.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@types/swagger-jsdoc": "6.0.4",
     "cleye": "1.3.4",
+    "es-module-lexer": "^2.3.2",
     "isarray": "2.0.5",
     "swagger-jsdoc": "6.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: 1.3.4
         version: 1.3.4
       es-module-lexer:
-        specifier: ^2.3.2
+        specifier: 2.3.2
         version: 2.3.2
       isarray:
         specifier: 2.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       cleye:
         specifier: 1.3.4
         version: 1.3.4
+      es-module-lexer:
+        specifier: ^2.3.2
+        version: 2.3.2
       isarray:
         specifier: 2.0.5
         version: 2.0.5
@@ -1265,6 +1268,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2989,6 +2995,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   esbuild@0.25.12:
     optionalDependencies:

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -35,19 +35,6 @@ function getApiSegments(apiFolder: string): string[] {
     : normalizedFolder.slice(routeRootIndex + 1);
 }
 
-function toOpenApiSegment(segment: string): string {
-  if (segment.startsWith('[[...') && segment.endsWith(']]')) {
-    return `{${segment.slice(5, -2)}}`;
-  }
-  if (segment.startsWith('[...') && segment.endsWith(']')) {
-    return `{${segment.slice(4, -1)}}`;
-  }
-  if (segment.startsWith('[') && segment.endsWith(']')) {
-    return `{${segment.slice(1, -1)}}`;
-  }
-  return segment;
-}
-
 function toOpenApiPaths(segments: string[]): string[] {
   const isOptionalCatchAll = (segment: string) =>
     segment.startsWith('[[...') && segment.endsWith(']]');
@@ -73,7 +60,7 @@ function toOpenApiPaths(segments: string[]): string[] {
     )
   );
 
-  return paths.map((path) => `/${path.map(toOpenApiSegment).join('/')}`);
+  return paths.map((path) => `/${path.join('/')}`);
 }
 
 /** Extract App Router API paths and exported HTTP methods from route files. */
@@ -86,6 +73,7 @@ export function extractApiInfo(
     join(cwd, '.next/server', apiFolder),
   ].filter(existsSync);
   const apiInfos = new Map<string, Set<string>>();
+  const apiSegments = getApiSegments(apiFolder);
 
   for (const apiDirectory of directories) {
     for (const file of getRouteFiles(apiDirectory)) {
@@ -93,10 +81,7 @@ export function extractApiInfo(
         .split(sep)
         .slice(0, -1);
       const methods = getExportedMethods(readFileSync(file, 'utf8'));
-      for (const path of toOpenApiPaths([
-        ...getApiSegments(apiFolder),
-        ...routeSegments,
-      ])) {
+      for (const path of toOpenApiPaths([...apiSegments, ...routeSegments])) {
         const pathMethods = apiInfos.get(path) ?? new Set<string>();
         methods.forEach((method) => pathMethods.add(method));
         apiInfos.set(path, pathMethods);

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -1,15 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 
-const HTTP_METHODS = [
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS',
-] as const;
+import { HTTP_METHODS, getExportedMethods } from './route-parser';
 
 export type ApiInfo = {
   path: string;
@@ -82,91 +74,6 @@ function toOpenApiPaths(segments: string[]): string[] {
   );
 
   return paths.map((path) => `/${path.map(toOpenApiSegment).join('/')}`);
-}
-
-function sanitizeSource(source: string): string {
-  let code = '';
-  let index = 0;
-
-  while (index < source.length) {
-    const character = source[index];
-    const nextCharacter = source[index + 1];
-    if (character === '/' && nextCharacter === '/') {
-      index = source.indexOf('\n', index);
-      if (index === -1) {
-        break;
-      }
-      code += '\n';
-    } else if (character === '/' && nextCharacter === '*') {
-      const commentEnd = source.indexOf('*/', index + 2);
-      if (commentEnd === -1) {
-        break;
-      }
-      code += ' ';
-      index = commentEnd + 2;
-      continue;
-    } else if (character === "'" || character === '"' || character === '`') {
-      const quote = character;
-      index += 1;
-      while (index < source.length && source[index] !== quote) {
-        index += source[index] === '\\' ? 2 : 1;
-      }
-    } else {
-      code += character;
-    }
-    index += 1;
-  }
-
-  return code;
-}
-
-function getExportedMethods(source: string): string[] {
-  const code = sanitizeSource(source);
-  const normalizedCode = Array.from(code)
-    .map((character) => (character <= ' ' ? ' ' : character))
-    .join('')
-    .split(' ')
-    .filter(Boolean)
-    .join(' ');
-  const methods = new Set<string>();
-
-  for (const method of HTTP_METHODS) {
-    if (
-      [
-        `export function ${method}`,
-        `export async function ${method}`,
-        `export const ${method}`,
-        `export let ${method}`,
-        `export var ${method}`,
-      ].some((declaration) => normalizedCode.includes(declaration))
-    ) {
-      methods.add(method);
-    }
-  }
-  let exportStart = code.indexOf('export {');
-  while (exportStart !== -1) {
-    const specifiersStart = exportStart + 'export {'.length;
-    const specifiersEnd = code.indexOf('}', specifiersStart);
-    if (specifiersEnd === -1) {
-      break;
-    }
-    for (const specifier of code
-      .slice(specifiersStart, specifiersEnd)
-      .split(',')) {
-      const exportedName = specifier.trim().split(' as ').at(-1);
-      if (
-        exportedName &&
-        HTTP_METHODS.includes(exportedName as (typeof HTTP_METHODS)[number])
-      ) {
-        methods.add(exportedName);
-      }
-    }
-    exportStart = code.indexOf('export {', specifiersEnd);
-  }
-
-  return HTTP_METHODS.filter((method) => methods.has(method)).map((method) =>
-    method.toLowerCase()
-  );
 }
 
 /** Extract App Router API paths and exported HTTP methods from route files. */

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 
 import { HTTP_METHODS, getExportedMethods } from './route-parser';
+import { routeToOpenApiPaths } from './route-path';
+import { discoverSpecLocations } from './spec-source';
 
 export type ApiInfo = {
   path: string;
@@ -24,64 +26,22 @@ function getRouteFiles(directory: string): string[] {
   });
 }
 
-function getApiSegments(apiFolder: string): string[] {
-  const normalizedFolder = apiFolder.split(/[\\/]/).filter(Boolean);
-  const appIndex = normalizedFolder.lastIndexOf('app');
-  const pagesIndex = normalizedFolder.lastIndexOf('pages');
-  const routeRootIndex = Math.max(appIndex, pagesIndex);
-
-  return routeRootIndex === -1
-    ? [normalizedFolder.at(-1) ?? 'api']
-    : normalizedFolder.slice(routeRootIndex + 1);
-}
-
-function toOpenApiPaths(segments: string[]): string[] {
-  const isOptionalCatchAll = (segment: string) =>
-    segment.startsWith('[[...') && segment.endsWith(']]');
-  const pathSegments = segments.filter(
-    (segment) =>
-      !(segment.startsWith('(') && segment.endsWith(')')) &&
-      !segment.startsWith('@')
-  );
-  const optionalCatchAllIndex = pathSegments.findIndex(isOptionalCatchAll);
-  const paths = (
-    optionalCatchAllIndex === -1
-      ? [pathSegments]
-      : [
-          pathSegments.filter((_, index) => index !== optionalCatchAllIndex),
-          pathSegments,
-        ]
-  ).map((path) =>
-    path.map((segment) =>
-      segment
-        .replace(/^\[\[\.\.\.(.+?)\]\]$/, '{$1}')
-        .replace(/^\[\.\.\.(.+?)\]$/, '{$1}')
-        .replace(/^\[(.+)\]$/, '{$1}')
-    )
-  );
-
-  return paths.map((path) => `/${path.join('/')}`);
-}
-
 /** Extract App Router API paths and exported HTTP methods from route files. */
 export function extractApiInfo(
   apiFolder: string,
   cwd = process.cwd()
 ): ApiInfo[] {
-  const directories = [
-    join(cwd, apiFolder),
-    join(cwd, '.next/server', apiFolder),
-  ].filter(existsSync);
+  const { sourceDirs, buildDirs } = discoverSpecLocations([apiFolder], cwd);
+  const directories = [...sourceDirs, ...buildDirs].filter(existsSync);
   const apiInfos = new Map<string, Set<string>>();
-  const apiSegments = getApiSegments(apiFolder);
 
   for (const apiDirectory of directories) {
     for (const file of getRouteFiles(apiDirectory)) {
       const routeSegments = relative(apiDirectory, file)
         .split(sep)
         .slice(0, -1);
-      const methods = getExportedMethods(readFileSync(file, 'utf8'));
-      for (const path of toOpenApiPaths([...apiSegments, ...routeSegments])) {
+      const methods = getExportedMethods(readFileSync(file, 'utf8'), file);
+      for (const path of routeToOpenApiPaths(apiFolder, routeSegments)) {
         const pathMethods = apiInfos.get(path) ?? new Set<string>();
         methods.forEach((method) => pathMethods.add(method));
         apiInfos.set(path, pathMethods);

--- a/src/merge-auto-doc.ts
+++ b/src/merge-auto-doc.ts
@@ -1,0 +1,21 @@
+export type PathsObject = Record<string, Record<string, unknown>>;
+
+/**
+ * Merge auto-generated paths with manually documented paths.
+ *
+ * The result is the union of both, with manual operations winning over
+ * generated ones per HTTP method.
+ */
+export function mergeAutoDoc(
+  autoPaths: PathsObject,
+  manualPaths: PathsObject
+): PathsObject {
+  return Object.fromEntries(
+    Object.entries({ ...autoPaths, ...manualPaths }).map(
+      ([path, operations]) => {
+        const generatedOperations = autoPaths[path] ?? {};
+        return [path, { ...generatedOperations, ...operations }];
+      }
+    )
+  );
+}

--- a/src/route-parser.ts
+++ b/src/route-parser.ts
@@ -19,13 +19,17 @@ initSync();
  * Uses es-module-lexer instead of hand-rolled string matching, so comments,
  * strings, and regex literals are handled correctly without sanitisation.
  */
-export function getExportedMethods(source: string): string[] {
+export function getExportedMethods(
+  source: string,
+  sourceName?: string
+): string[] {
   let exportSpecifiers: readonly ExportSpecifier[] = [];
   try {
     [, exportSpecifiers] = parse(source);
   } catch (error) {
+    const location = sourceName ? ` (${sourceName})` : '';
     console.warn(
-      'next-swagger-doc: failed to parse route source, skipping file',
+      `next-swagger-doc: failed to parse route source${location}, skipping file`,
       error
     );
     return [];

--- a/src/route-parser.ts
+++ b/src/route-parser.ts
@@ -20,9 +20,9 @@ initSync();
  * strings, and regex literals are handled correctly without sanitisation.
  */
 export function getExportedMethods(source: string): string[] {
-  let exports: readonly ExportSpecifier[] = [];
+  let exportSpecifiers: readonly ExportSpecifier[] = [];
   try {
-    [, exports] = parse(source);
+    [, exportSpecifiers] = parse(source);
   } catch (error) {
     console.warn(
       'next-swagger-doc: failed to parse route source, skipping file',
@@ -30,13 +30,8 @@ export function getExportedMethods(source: string): string[] {
     );
     return [];
   }
-  const methods = new Set<string>();
-  for (const { n } of exports) {
-    if (HTTP_METHODS.includes(n as (typeof HTTP_METHODS)[number])) {
-      methods.add(n);
-    }
-  }
-  return HTTP_METHODS.filter((method) => methods.has(method)).map((method) =>
-    method.toLowerCase()
+  const exportedNames = new Set(exportSpecifiers.map(({ n }) => n));
+  return HTTP_METHODS.filter((method) => exportedNames.has(method)).map(
+    (method) => method.toLowerCase()
   );
 }

--- a/src/route-parser.ts
+++ b/src/route-parser.ts
@@ -1,0 +1,42 @@
+import { initSync, parse, type ExportSpecifier } from 'es-module-lexer';
+
+export const HTTP_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+
+// es-module-lexer needs its WASM engine ready before parse() can run.
+initSync();
+
+/**
+ * Extract the exported HTTP method handler names from a route module's source.
+ *
+ * Uses es-module-lexer instead of hand-rolled string matching, so comments,
+ * strings, and regex literals are handled correctly without sanitisation.
+ */
+export function getExportedMethods(source: string): string[] {
+  let exports: readonly ExportSpecifier[] = [];
+  try {
+    [, exports] = parse(source);
+  } catch (error) {
+    console.warn(
+      'next-swagger-doc: failed to parse route source, skipping file',
+      error
+    );
+    return [];
+  }
+  const methods = new Set<string>();
+  for (const { n } of exports) {
+    if (HTTP_METHODS.includes(n as (typeof HTTP_METHODS)[number])) {
+      methods.add(n);
+    }
+  }
+  return HTTP_METHODS.filter((method) => methods.has(method)).map((method) =>
+    method.toLowerCase()
+  );
+}

--- a/src/route-path.ts
+++ b/src/route-path.ts
@@ -1,0 +1,49 @@
+/**
+ * Translate a Next.js route directory into OpenAPI paths.
+ *
+ * Owns all Next.js folder conventions in one place: the app/pages root,
+ * route groups `(…)`, parallel routes `@…`, dynamic segments `[id]`,
+ * catch-alls `[...slug]`, and optional catch-alls `[[...slug]]`.
+ */
+export function routeToOpenApiPaths(
+  apiFolder: string,
+  routeSegments: string[]
+): string[] {
+  const segments = [...getApiSegments(apiFolder), ...routeSegments];
+  const isOptionalCatchAll = (segment: string) =>
+    segment.startsWith('[[...') && segment.endsWith(']]');
+  const pathSegments = segments.filter(
+    (segment) =>
+      !(segment.startsWith('(') && segment.endsWith(')')) &&
+      !segment.startsWith('@')
+  );
+  const optionalCatchAllIndex = pathSegments.findIndex(isOptionalCatchAll);
+  const paths = (
+    optionalCatchAllIndex === -1
+      ? [pathSegments]
+      : [
+          pathSegments.filter((_, index) => index !== optionalCatchAllIndex),
+          pathSegments,
+        ]
+  ).map((path) =>
+    path.map((segment) =>
+      segment
+        .replace(/^\[\[\.\.\.(.+?)\]\]$/, '{$1}')
+        .replace(/^\[\.\.\.(.+?)\]$/, '{$1}')
+        .replace(/^\[(.+)\]$/, '{$1}')
+    )
+  );
+
+  return paths.map((path) => `/${path.join('/')}`);
+}
+
+function getApiSegments(apiFolder: string): string[] {
+  const normalizedFolder = apiFolder.split(/[\\/]/).filter(Boolean);
+  const appIndex = normalizedFolder.lastIndexOf('app');
+  const pagesIndex = normalizedFolder.lastIndexOf('pages');
+  const routeRootIndex = Math.max(appIndex, pagesIndex);
+
+  return routeRootIndex === -1
+    ? [normalizedFolder.at(-1) ?? 'api']
+    : normalizedFolder.slice(routeRootIndex + 1);
+}

--- a/src/spec-source.ts
+++ b/src/spec-source.ts
@@ -1,0 +1,24 @@
+import { join } from 'node:path';
+
+export type SpecLocations = {
+  sourceDirs: string[];
+  buildDirs: string[];
+  publicDir: string;
+};
+
+/**
+ * Discover where route documentation can live for a set of folders.
+ *
+ * Owns the Next.js build-output layout (`.next/server/<folder>`) and the
+ * public static-docs directory, so consumers don't re-derive them.
+ */
+export function discoverSpecLocations(
+  folders: string[],
+  cwd = process.cwd()
+): SpecLocations {
+  return {
+    sourceDirs: folders.map((folder) => join(cwd, folder)),
+    buildDirs: folders.map((folder) => join(cwd, '.next/server', folder)),
+    publicDir: join(cwd, 'public'),
+  };
+}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -3,6 +3,8 @@ import { dirname, isAbsolute, join } from 'node:path';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import swaggerJsdoc, { type OAS3Definition, type Options } from 'swagger-jsdoc';
 import { extractApiInfo, generateAutoDoc } from './auto-doc';
+import { mergeAutoDoc } from './merge-auto-doc';
+import { discoverSpecLocations } from './spec-source';
 
 export type AutoDocOptions = {
   enabled?: boolean;
@@ -143,33 +145,33 @@ export function createSwaggerSpec({
   }
 
   const scanFolders = [apiFolder, ...schemaFolders];
-  const apis = scanFolders.flatMap((folder) => {
-    const buildApiDirectory = join(process.cwd(), '.next/server', folder);
-    const apiDirectory = join(process.cwd(), folder);
-    const publicDirectory = join(process.cwd(), 'public');
-    const fileTypes = ['ts', 'tsx', 'jsx', 'js', 'json', 'swagger.yaml'];
-    const paths = [
-      ...fileTypes.map((fileType) => `${apiDirectory}/**/*.${fileType}`),
-      // Support load static files from public directory
-      ...['swagger.yaml', 'json'].map(
-        (fileType) => `${publicDirectory}/**/*.${fileType}`
-      ),
-    ];
-    if (
-      shouldScanBuildDirectory({
-        sourceDirectory: apiDirectory,
-        buildDirectory: buildApiDirectory,
-        scanBuildOutput,
-      })
-    ) {
-      paths.push(
-        ...['js', 'swagger.yaml', 'json'].map(
-          (fileType) => `${buildApiDirectory}/**/*.${fileType}`
-        )
+  const { sourceDirs, buildDirs, publicDir } =
+    discoverSpecLocations(scanFolders);
+  const fileTypes = ['ts', 'tsx', 'jsx', 'js', 'json', 'swagger.yaml'];
+  const apis = [
+    ...sourceDirs.flatMap((dir) =>
+      fileTypes.map((fileType) => `${dir}/**/*.${fileType}`)
+    ),
+    ...['swagger.yaml', 'json'].map(
+      (fileType) => `${publicDir}/**/*.${fileType}`
+    ),
+    ...sourceDirs.flatMap((sourceDirectory, index) => {
+      const buildDirectory = buildDirs[index];
+      if (
+        !buildDirectory ||
+        !shouldScanBuildDirectory({
+          sourceDirectory,
+          buildDirectory,
+          scanBuildOutput,
+        })
+      ) {
+        return [];
+      }
+      return ['js', 'swagger.yaml', 'json'].map(
+        (fileType) => `${buildDirectory}/**/*.${fileType}`
       );
-    }
-    return paths;
-  });
+    }),
+  ];
 
   // Append base path server element to server array
   // Conditions: basePath is specified. Server array is not defined.
@@ -196,14 +198,7 @@ export function createSwaggerSpec({
 
   if (isAutoDocEnabled(autoDoc, !existsSync(sourceDirectory))) {
     const autoPaths = generateAutoDoc(extractApiInfo(apiFolder));
-    spec.paths = Object.fromEntries(
-      Object.entries({ ...autoPaths, ...spec.paths }).map(
-        ([path, operations]) => {
-          const generatedOperations = autoPaths[path] ?? {};
-          return [path, { ...generatedOperations, ...operations }];
-        }
-      )
-    );
+    spec.paths = mergeAutoDoc(autoPaths, spec.paths ?? {}) as OAS3Definition['paths'];
   }
 
   if (outputFile) {

--- a/test/fixtures/app/api/regex/route.ts
+++ b/test/fixtures/app/api/regex/route.ts
@@ -1,0 +1,5 @@
+const URL_PATTERN = /^https?:\/\/[^\/*]*$/;
+
+export function GET() {
+  return new Response(String(URL_PATTERN.test('https://example.com')));
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -108,11 +108,18 @@ describe('withSwagger', () => {
     expect(extractApiInfo('test/fixtures/app')).toEqual([
       { path: '/api/health', methods: ['get', 'head'] },
       { path: '/api/manual', methods: ['get'] },
+      { path: '/api/regex', methods: ['get'] },
       { path: '/api/users/{id}', methods: ['patch', 'delete'] },
       { path: '/blog', methods: ['get'] },
       { path: '/blog/{slug}', methods: ['get'] },
       { path: '/commented', methods: ['get'] },
       { path: '/users', methods: ['get', 'post'] },
+    ]);
+  });
+
+  it('detects handlers despite regex literals containing comment-like sequences', () => {
+    expect(extractApiInfo('test/fixtures/app/api/regex')).toEqual([
+      { path: '/api/regex', methods: ['get'] },
     ]);
   });
 
@@ -164,6 +171,7 @@ describe('withSwagger', () => {
     expect(extractApiInfo('test/fixtures/app/api')).toEqual([
       { path: '/api/health', methods: ['get', 'head'] },
       { path: '/api/manual', methods: ['get'] },
+      { path: '/api/regex', methods: ['get'] },
       { path: '/api/users/{id}', methods: ['patch', 'delete'] },
     ]);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,6 +15,9 @@ import {
   isAutoDocEnabled,
   shouldScanBuildDirectory,
 } from '../src';
+import { mergeAutoDoc } from '../src/merge-auto-doc';
+import { routeToOpenApiPaths } from '../src/route-path';
+import { discoverSpecLocations } from '../src/spec-source';
 
 describe('withSwagger', () => {
   it('should create default swagger json option', () => {
@@ -320,5 +323,102 @@ describe('standalone spec files', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe('routeToOpenApiPaths', () => {
+  it('derives the api base path from the api folder', () => {
+    expect(routeToOpenApiPaths('app/api', [])).toEqual(['/api']);
+    expect(routeToOpenApiPaths('src/app/api', ['users'])).toEqual([
+      '/api/users',
+    ]);
+    expect(routeToOpenApiPaths('pages/api', ['hello'])).toEqual([
+      '/api/hello',
+    ]);
+  });
+
+  it('translates dynamic and catch-all segments', () => {
+    expect(routeToOpenApiPaths('app/api', ['users', '[id]'])).toEqual([
+      '/api/users/{id}',
+    ]);
+    expect(routeToOpenApiPaths('app/api', ['blog', '[...slug]'])).toEqual([
+      '/api/blog/{slug}',
+    ]);
+  });
+
+  it('expands optional catch-alls into two paths', () => {
+    expect(routeToOpenApiPaths('app/api', ['blog', '[[...slug]]'])).toEqual([
+      '/api/blog',
+      '/api/blog/{slug}',
+    ]);
+  });
+
+  it('drops route groups and parallel route segments', () => {
+    expect(routeToOpenApiPaths('app/api', ['(admin)', 'users'])).toEqual([
+      '/api/users',
+    ]);
+    expect(routeToOpenApiPaths('app/api', ['@modal', 'users'])).toEqual([
+      '/api/users',
+    ]);
+  });
+});
+
+describe('discoverSpecLocations', () => {
+  it('maps folders to source and build directories plus public', () => {
+    const cwd = join('app');
+    expect(discoverSpecLocations(['api', 'models'], cwd)).toEqual({
+      sourceDirs: [join('app', 'api'), join('app', 'models')],
+      buildDirs: [
+        join('app', '.next', 'server', 'api'),
+        join('app', '.next', 'server', 'models'),
+      ],
+      publicDir: join('app', 'public'),
+    });
+  });
+});
+
+describe('mergeAutoDoc', () => {
+  it('keeps manual and auto-only paths and lets manual win per method', () => {
+    const autoPaths = {
+      '/api/health': { get: { summary: 'GET /api/health' } },
+      '/api/users/{id}': { delete: { summary: 'DELETE /api/users/{id}' } },
+    };
+    const manualPaths = {
+      '/api/health': {
+        get: {
+          summary: 'Manual health',
+          responses: { 200: { description: 'OK' } },
+        },
+      },
+      '/api/manual': { get: { summary: 'Manual only' } },
+    };
+    expect(mergeAutoDoc(autoPaths, manualPaths)).toEqual({
+      '/api/health': {
+        get: {
+          summary: 'Manual health',
+          responses: { 200: { description: 'OK' } },
+        },
+      },
+      '/api/manual': { get: { summary: 'Manual only' } },
+      '/api/users/{id}': { delete: { summary: 'DELETE /api/users/{id}' } },
+    });
+  });
+
+  it('merges different methods on the same path', () => {
+    const autoPaths = { '/api/x': { get: { summary: 'auto get' } } };
+    const manualPaths = { '/api/x': { post: { summary: 'manual post' } } };
+    expect(mergeAutoDoc(autoPaths, manualPaths)).toEqual({
+      '/api/x': {
+        get: { summary: 'auto get' },
+        post: { summary: 'manual post' },
+      },
+    });
+  });
+
+  it('returns manual paths unchanged when auto is empty and vice versa', () => {
+    const manual = { '/api/m': { get: { summary: 'm' } } };
+    expect(mergeAutoDoc({}, manual)).toEqual(manual);
+    const auto = { '/api/a': { get: { summary: 'a' } } };
+    expect(mergeAutoDoc(auto, {})).toEqual(auto);
   });
 });


### PR DESCRIPTION
## What

Replace the hand-rolled comment/string stripper and string matching in `getExportedMethods` with `es-module-lexer`, a real lexer that correctly handles comments, strings, and regex literals. The parser moves into a new `src/route-parser.ts` module; `sanitizeSource` is deleted. Follow-up cleanup removes a redundant path conversion and repeated computation.

## Why

The previous string-matching approach silently missed exported HTTP handlers when route source contained regex literals with comment-like sequences (e.g. `/^https?:\\/\\/[^\\/*]*$/`), because the hand-rolled sanitizer misread `/*` inside a regex as a block comment and truncated the source. Real route files are TS/JS, and a proper lexer makes handler detection robust for any valid source.

## How

- Added `src/route-parser.ts` with `getExportedMethods(source)` using es-module-lexer v2 (`initSync` + `parse`), preserving the exact interface callers use
- Removed `sanitizeSource` and the old `getExportedMethods` from `src/auto-doc.ts` (~110 lines of fragile parsing)
- Per-file parse failures warn and skip the file instead of crashing doc generation
- Added `es-module-lexer` as a runtime dependency (externalized by pkgroll — no native/WASM bundling)
- Added a regex-literal fixture and a regression test; existing extraction tests updated
- Cleanup: removed the redundant `toOpenApiSegment` conversion (already handled by regex in `toOpenApiPaths`), hoisted the api-folder segment computation out of the per-file loop, and simplified the export collection

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)