### PR TITLE
docs: add AGENTS.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+Instructions for AI coding agents working on `next-swagger-doc`.
+
+## Project
+
+Generate an OpenAPI (Swagger) spec from Next.js API routes. JSDoc `@swagger` blocks are parsed by `swagger-jsdoc`. App Router `route.ts` files can also get basic operations from folder paths and exported HTTP handlers when `autoDoc` is enabled.
+
+- Runtime: Node.js >= 18
+- Package manager: pnpm 10.9.0 (Corepack)
+- Language: TypeScript (strict, ESM)
+
+## Setup
+
+```sh
+corepack enable
+corepack pnpm@10.9.0 install --frozen-lockfile
+```
+
+`.agents/setup` runs the same install. No extra services need to be started.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Install | `pnpm install` |
+| Test | `pnpm test` |
+| Coverage | `pnpm coverage` |
+| Lint | `pnpm lint` |
+| Format check | `pnpm format` |
+| Build | `pnpm build` |
+
+Use Vitest for tests. Prefer real fixtures under `test/fixtures` over mocks.
+
+## Layout
+
+- `src/swagger.ts` — `createSwaggerSpec` and `withSwagger`
+- `src/auto-doc.ts` — App Router path/method extraction
+- `src/cli.ts` — `next-swagger-doc-cli`
+- `src/index.ts` — public exports
+- `test/` — Vitest tests and snapshots
+- `examples/` — Next.js 13/14/15 demo apps (separate lockfiles)
+
+Do not edit `dist/`; pkgroll writes it from `src/`.
+
+## Style
+
+- Biome formats and lints `src` (2-space indent, 80-column line width)
+- Keep TypeScript strict; avoid `any`
+- Document new options on `SwaggerOptions` and in `README.md`
+- Conventional commits: `feat`, `fix`, `chore`, `docs`, `test`
+
+## API notes
+
+- `apiFolder` defaults to `pages/api`. App Router apps typically pass `app/api`.
+- `autoDoc: true` fills in operations from `route` files. Manual `@swagger` JSDoc wins on conflict.
+- `createSwaggerSpec` globs the source API folder, `public` OpenAPI files, and `.next/server` compiled output. Prefer source files when they exist.
+
+## Examples
+
+Example apps depend on published `next-swagger-doc`. Library changes are verified with `pnpm test` in the repo root, not by rewriting example lockfiles unless the task is specifically about an example.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` so coding agents have project-specific setup, commands, layout, and API notes.

This is the bottom of a four-layer stack for open issues:

1. **#1245** (this PR) — `AGENTS.md` (#1216)
2. **#1248** — skip `.next` glob during Vercel/Next builds (#1157)
3. **#1247** — standalone `specFile` / autoDoc fallback (#1228)
4. **#1246** — swagger-ui-react Strict Mode warning (#1231)

Merge this layer first; the PRs above retarget automatically.

Fixes #1216
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance covering architecture, setup, development commands, coding standards, API behavior, and example-app testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->