### PR TITLE
docs: note swagger-ui-react Strict Mode warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Do not edit `dist/`; pkgroll writes it from `src/`.
 - `autoDoc: true` fills in operations from `route` files. Manual `@swagger` JSDoc wins on conflict.
 - Do not glob `.next` while Next.js is compiling (`NEXT_PHASE` production build/export). That walk can fail Vercel builds with a missing `export-detail.json`. Scan compiled output only when the source folder is missing, or set `scanBuildOutput: true`.
 - For `output: 'standalone'`, generate a spec at build time (`specFile` / CLI `outputFile`) or rely on `autoDoc` so compiled routes still document. `autoDoc` falls back on automatically when the source API folder is missing unless it is set to `false`.
+- `UNSAFE_componentWillReceiveProps` warnings for `ExamplesSelect` / `ParameterRow` come from `swagger-ui-react`, not this library. Keep examples on `next/dynamic` with `ssr: false`, or point users at Scalar / Stoplight Elements.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -81,16 +81,20 @@ Generate a new file named `app/api-doc/react-swagger.tsx`. In this file, create 
 
 For demonstration purposes, here is an example using [swagger-ui-react](https://www.npmjs.com/package/swagger-ui-react)
 
-Feel free to employ any alternative swagger UI library, such as [stoplightio/elements](https://github.com/stoplightio/elements). I have added an [example ](https://github.com/jellydn/next-swagger-doc/blob/main/examples/next13-simple/pages/playground.tsx)using this library in the `example` folder.
+Feel free to employ any alternative swagger UI library, such as [stoplightio/elements](https://github.com/stoplightio/elements) or [Scalar](https://github.com/scalar/scalar). I have added an [example](https://github.com/jellydn/next-swagger-doc/blob/main/examples/next13-simple/pages/playground.tsx) using Stoplight Elements in the `example` folder.
+
+Load `swagger-ui-react` on the client only. Next.js enables React Strict Mode by default, and `swagger-ui-react` still uses `UNSAFE_componentWillReceiveProps` in components such as `ExamplesSelect` and `ParameterRow`. That warning comes from Swagger UI, not this library.
 
 ```javascript
 'use client';
 
-import SwaggerUI from 'swagger-ui-react';
+import dynamic from 'next/dynamic';
 import 'swagger-ui-react/swagger-ui.css';
 
+const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false });
+
 type Props = {
-  spec: Record<string, any>,
+  spec: Record<string, unknown>,
 };
 
 function ReactSwagger({ spec }: Props) {
@@ -191,6 +195,16 @@ const spec = createSwaggerSpec({
 ```
 
 If `specFile` is missing at runtime, `autoDoc` still documents compiled `route.js` handlers under `.next/server` (paths and methods only; JSDoc comments are stripped from compiled output). You can also set `outputFile` to write the spec when source files are present.
+
+### swagger-ui-react Strict Mode warning
+
+React may log `UNSAFE_componentWillReceiveProps` for `ExamplesSelect` and `ParameterRow`. Those components live in `swagger-ui-react`, which this package does not depend on. Next.js turns Strict Mode on by default.
+
+Workarounds:
+
+- Render Swagger UI with `next/dynamic(..., { ssr: false })` as shown in Usage #1
+- Switch the viewer to [Scalar](https://github.com/scalar/scalar) or [Stoplight Elements](https://github.com/stoplightio/elements)
+- Ignore the warning until Swagger UI drops the unsafe lifecycles
 
 ## Usage #2: Create an single API document
 

--- a/examples/next15-app/app/api-doc/react-swagger.tsx
+++ b/examples/next15-app/app/api-doc/react-swagger.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import SwaggerUI from 'swagger-ui-react';
+import dynamic from 'next/dynamic';
 
 import 'swagger-ui-react/swagger-ui.css';
 
+const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false });
+
 type Props = {
-  spec: Record<string, any>;
+  spec: Record<string, unknown>;
 };
 
 function ReactSwagger({ spec }: Props) {
-  // @ts-ignore - SwaggerUI is not typed
+  // swagger-ui-react still uses UNSAFE_componentWillReceiveProps
+  // (ExamplesSelect, ParameterRow). That Strict Mode warning is from
+  // Swagger UI, not next-swagger-doc.
   return <SwaggerUI spec={spec} />;
 }
 

--- a/examples/next16-app/app/api-doc/react-swagger.tsx
+++ b/examples/next16-app/app/api-doc/react-swagger.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import SwaggerUI from 'swagger-ui-react';
+import dynamic from 'next/dynamic';
 
 import 'swagger-ui-react/swagger-ui.css';
 
+const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false });
+
 type Props = {
-  spec: Record<string, any>;
+  spec: Record<string, unknown>;
 };
 
 function ReactSwagger({ spec }: Props) {
-  // @ts-ignore - SwaggerUI is not typed
+  // swagger-ui-react still uses UNSAFE_componentWillReceiveProps
+  // (ExamplesSelect, ParameterRow). That Strict Mode warning is from
+  // Swagger UI, not next-swagger-doc.
   return <SwaggerUI spec={spec} />;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
React Strict Mode logs `UNSAFE_componentWillReceiveProps` for `ExamplesSelect` and `ParameterRow` when using `swagger-ui-react`. Those components are upstream Swagger UI, not this library.

This layer documents the warning, loads the viewer with `next/dynamic(..., { ssr: false })` in Usage #1 and the Next 15 example, and points at Scalar / Stoplight Elements as alternatives.

Stack:

1. #1245 — `AGENTS.md`
2. #1248 — Vercel/Next `.next` scan
3. #1247 — standalone spec
4. **#1246** (this PR) — swagger-ui-react Strict Mode (#1231)

Base: `cursor/standalone-spec-69d3` (#1247).

Fixes #1231
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

