### PR TITLE
feat: load prebuilt specs for standalone output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Do not edit `dist/`; pkgroll writes it from `src/`.
 - `apiFolder` defaults to `pages/api`. App Router apps typically pass `app/api`.
 - `autoDoc: true` fills in operations from `route` files. Manual `@swagger` JSDoc wins on conflict.
 - Do not glob `.next` while Next.js is compiling (`NEXT_PHASE` production build/export). That walk can fail Vercel builds with a missing `export-detail.json`. Scan compiled output only when the source folder is missing, or set `scanBuildOutput: true`.
+- For `output: 'standalone'`, generate a spec at build time (`specFile` / CLI `outputFile`) or rely on `autoDoc` so compiled routes still document. `autoDoc` falls back on automatically when the source API folder is missing unless it is set to `false`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js app
 
 `createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public` OpenAPI files are scanned instead. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
 
+### Next.js standalone output
+
+`output: 'standalone'` copies a minimal server. Source `app/api` files are not included, so scanning routes at runtime yields an empty spec.
+
+Generate the document at build time and load it from `public/` (copied into the standalone output):
+
+```sh
+npx next-swagger-doc-cli next-swagger-doc.json --output public/swagger.json
+```
+
+```javascript
+const spec = createSwaggerSpec({
+  specFile: 'public/swagger.json',
+  apiFolder: 'app/api',
+  autoDoc: true,
+  definition: {
+    openapi: '3.0.0',
+    info: { title: 'Next Swagger API Example', version: '1.0' },
+  },
+});
+```
+
+If `specFile` is missing at runtime, `autoDoc` still documents compiled `route.js` handlers under `.next/server` (paths and methods only; JSDoc comments are stripped from compiled output). You can also set `outputFile` to write the spec when source files are present.
+
 ## Usage #2: Create an single API document
 
 ```sh

--- a/examples/next15-app/lib/swagger.ts
+++ b/examples/next15-app/lib/swagger.ts
@@ -5,6 +5,8 @@ import 'server-only';
 export const getApiDocs = async () => {
   const spec = createSwaggerSpec({
     apiFolder: 'app/api',
+    specFile: 'public/swagger.json',
+    autoDoc: true,
     definition: {
       openapi: '3.0.0',
       info: {

--- a/examples/next16-app/lib/swagger.ts
+++ b/examples/next16-app/lib/swagger.ts
@@ -5,6 +5,8 @@ import 'server-only';
 export const getApiDocs = async () => {
   const spec = createSwaggerSpec({
     apiFolder: 'app/api',
+    specFile: 'public/swagger.json',
+    autoDoc: true,
     definition: {
       openapi: '3.0.0',
       info: {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import swaggerJsdoc, { type OAS3Definition, type Options } from 'swagger-jsdoc';
 import { extractApiInfo, generateAutoDoc } from './auto-doc';
@@ -12,7 +12,14 @@ export type SwaggerOptions = Options & {
   apiFolder?: string;
   schemaFolders?: string[];
   definition: OAS3Definition;
+  /** Write the generated spec to this JSON file. */
   outputFile?: string;
+  /**
+   * Load a prebuilt OpenAPI JSON file (for example `public/swagger.json`).
+   * When the file exists it is returned as-is, which is the standalone-output
+   * path: generate at build time, serve the file at runtime.
+   */
+  specFile?: string;
   /** Generate basic OpenAPI operations from App Router route files. */
   autoDoc?: boolean | AutoDocOptions;
   /**
@@ -60,6 +67,48 @@ export function shouldScanBuildDirectory({
   return !existsSync(sourceDirectory);
 }
 
+/** Resolve a user-supplied path against the process working directory. */
+function resolveUserPath(file: string, cwd = process.cwd()): string {
+  return isAbsolute(file) ? file : join(cwd, file);
+}
+
+/**
+ * Read a prebuilt OpenAPI document. Returns `undefined` when the file is
+ * missing so callers can fall back to scanning source or compiled routes.
+ */
+export function loadSpecFile(
+  specFile: string,
+  cwd = process.cwd()
+): OAS3Definition | undefined {
+  const specPath = resolveUserPath(specFile, cwd);
+  if (!existsSync(specPath)) {
+    return undefined;
+  }
+  return JSON.parse(readFileSync(specPath, 'utf8')) as OAS3Definition;
+}
+
+/**
+ * Auto-doc is on when requested, and also as a standalone fallback when the
+ * source API folder is missing (compiled `route.js` files may still exist).
+ */
+export function isAutoDocEnabled(
+  autoDoc: boolean | AutoDocOptions | undefined,
+  sourceMissing: boolean
+): boolean {
+  if (autoDoc === false) {
+    return false;
+  }
+  if (autoDoc === true) {
+    return true;
+  }
+  if (typeof autoDoc === 'object') {
+    return (
+      autoDoc.enabled !== false && Boolean(autoDoc.enabled || sourceMissing)
+    );
+  }
+  return sourceMissing;
+}
+
 const defaultOptions: SwaggerOptions = {
   apiFolder: 'pages/api',
   schemaFolders: [],
@@ -84,10 +133,19 @@ const defaultOptions: SwaggerOptions = {
 export function createSwaggerSpec({
   apiFolder = 'pages/api',
   schemaFolders = [],
-  autoDoc = false,
+  autoDoc,
   scanBuildOutput,
+  specFile,
+  outputFile,
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
+  if (specFile) {
+    const saved = loadSpecFile(specFile);
+    if (saved) {
+      return saved;
+    }
+  }
+
   const scanFolders = [apiFolder, ...schemaFolders];
   const apis = scanFolders.flatMap((folder) => {
     const buildApiDirectory = join(process.cwd(), '.next/server', folder);
@@ -138,8 +196,9 @@ export function createSwaggerSpec({
     definition,
   };
   const spec = swaggerJsdoc(options) as OAS3Definition;
+  const sourceDirectory = join(process.cwd(), apiFolder);
 
-  if (autoDoc === true || (typeof autoDoc === 'object' && autoDoc.enabled)) {
+  if (isAutoDocEnabled(autoDoc, !existsSync(sourceDirectory))) {
     const autoPaths = generateAutoDoc(extractApiInfo(apiFolder));
     spec.paths = Object.fromEntries(
       Object.entries({ ...autoPaths, ...spec.paths }).map(
@@ -149,6 +208,12 @@ export function createSwaggerSpec({
         }
       )
     );
+  }
+
+  if (outputFile) {
+    const outputPath = resolveUserPath(outputFile);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify(spec, null, 2));
   }
 
   return spec;
@@ -166,7 +231,7 @@ export function createSwaggerSpec({
 export function withSwagger({
   apiFolder = 'pages/api',
   schemaFolders = [],
-  autoDoc = false,
+  autoDoc,
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   return () => (_req: NextApiRequest, res: NextApiResponse) => {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -95,16 +95,12 @@ export function isAutoDocEnabled(
   autoDoc: boolean | AutoDocOptions | undefined,
   sourceMissing: boolean
 ): boolean {
-  if (autoDoc === false) {
+  const enabled = typeof autoDoc === 'object' ? autoDoc.enabled : autoDoc;
+  if (enabled === false) {
     return false;
   }
-  if (autoDoc === true) {
+  if (enabled === true) {
     return true;
-  }
-  if (typeof autoDoc === 'object') {
-    return (
-      autoDoc.enabled !== false && Boolean(autoDoc.enabled || sourceMissing)
-    );
   }
   return sourceMissing;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 
 import {
   createSwaggerSpec,
   extractApiInfo,
+  isAutoDocEnabled,
   shouldScanBuildDirectory,
 } from '../src';
 
@@ -233,6 +234,75 @@ describe('shouldScanBuildDirectory', () => {
           scanBuildOutput: false,
         })
       ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isAutoDocEnabled', () => {
+  it('keeps autoDoc off when source files exist', () => {
+    expect(isAutoDocEnabled(undefined, false)).toBe(false);
+    expect(isAutoDocEnabled(false, true)).toBe(false);
+  });
+
+  it('falls back to autoDoc when the source folder is missing', () => {
+    expect(isAutoDocEnabled(undefined, true)).toBe(true);
+    expect(isAutoDocEnabled(true, false)).toBe(true);
+    expect(isAutoDocEnabled({ enabled: true }, false)).toBe(true);
+  });
+});
+
+describe('standalone spec files', () => {
+  it('returns a prebuilt specFile without scanning routes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+    const specFile = join(root, 'swagger.json');
+    try {
+      writeFileSync(
+        specFile,
+        JSON.stringify({
+          openapi: '3.0.0',
+          info: { title: 'Standalone', version: '1.0.0' },
+          paths: {
+            '/api/hello': {
+              get: { responses: { 200: { description: 'ok' } } },
+            },
+          },
+        })
+      );
+      const spec = createSwaggerSpec({
+        specFile,
+        apiFolder: join(root, 'missing-api'),
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'Ignored', version: '0' },
+        },
+      });
+      expect(spec.info.title).toBe('Standalone');
+      expect(spec.paths?.['/api/hello']).toBeDefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes the generated spec to outputFile', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-out-'));
+    const outputFile = join(root, 'public/swagger.json');
+    try {
+      const spec = createSwaggerSpec({
+        apiFolder: 'test/fixtures/app/api',
+        autoDoc: true,
+        outputFile,
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'Written', version: '1.0.0' },
+        },
+      });
+      const saved = JSON.parse(readFileSync(outputFile, 'utf8')) as {
+        info: { title: string };
+      };
+      expect(saved.info.title).toBe('Written');
+      expect(spec.info.title).toBe('Written');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Standalone Next.js builds omit `app/api` source files, so runtime scans produced an empty spec.

This layer adds:

- `specFile` to load a prebuilt OpenAPI JSON (generate with the CLI into `public/`)
- `outputFile` to write the generated spec
- `autoDoc` fallback when the source API folder is missing, so compiled `route.js` handlers still document paths and methods

Stack:

1. #1245 — `AGENTS.md`
2. #1248 — Vercel/Next `.next` scan
3. **#1247** (this PR) — standalone spec (#1228)
4. #1246 — swagger-ui-react Strict Mode

Base: `cursor/safe-api-scan-69d3` (#1248).

Fixes #1228
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

