### PR TITLE
fix: skip .next glob during Next.js builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Do not edit `dist/`; pkgroll writes it from `src/`.
 
 - `apiFolder` defaults to `pages/api`. App Router apps typically pass `app/api`.
 - `autoDoc: true` fills in operations from `route` files. Manual `@swagger` JSDoc wins on conflict.
-- `createSwaggerSpec` globs the source API folder, `public` OpenAPI files, and `.next/server` compiled output. Prefer source files when they exist.
+- Do not glob `.next` while Next.js is compiling (`NEXT_PHASE` production build/export). That walk can fail Vercel builds with a missing `export-detail.json`. Scan compiled output only when the source folder is missing, or set `scanBuildOutput: true`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js app
 
 ![https://gyazo.com/6bfa919c4969b000615df6bb9cabcd02.gif](https://gyazo.com/6bfa919c4969b000615df6bb9cabcd02.gif)
 
+### Vercel builds
+
+`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public` OpenAPI files are scanned instead. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
+
 ## Usage #2: Create an single API document
 
 ```sh

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import swaggerJsdoc, { type OAS3Definition, type Options } from 'swagger-jsdoc';
@@ -14,7 +15,50 @@ export type SwaggerOptions = Options & {
   outputFile?: string;
   /** Generate basic OpenAPI operations from App Router route files. */
   autoDoc?: boolean | AutoDocOptions;
+  /**
+   * Glob compiled files under `.next/server`.
+   * Default: only when the source API folder is missing and Next.js is not
+   * currently compiling (standalone / runtime fallback).
+   */
+  scanBuildOutput?: boolean;
 };
+
+/** Next.js phases that rewrite `.next` and must not be globbed. */
+const NEXT_BUILD_PHASES = new Set([
+  'phase-production-build',
+  'phase-production-compile',
+  'phase-export',
+]);
+
+/**
+ * Whether compiled files under `.next/server` should be globbed.
+ *
+ * Globbing `.next` while Next.js is compiling can fail Vercel builds with
+ * `ENOENT: .../.next/export-detail.json`. Prefer source files; scan compiled
+ * output only as a runtime fallback when the source folder is gone.
+ */
+export function shouldScanBuildDirectory({
+  sourceDirectory,
+  buildDirectory,
+  scanBuildOutput,
+  nextPhase = process.env.NEXT_PHASE,
+}: {
+  sourceDirectory: string;
+  buildDirectory: string;
+  scanBuildOutput?: boolean;
+  nextPhase?: string;
+}): boolean {
+  if (!existsSync(buildDirectory) || scanBuildOutput === false) {
+    return false;
+  }
+  if (scanBuildOutput === true) {
+    return true;
+  }
+  if (nextPhase && NEXT_BUILD_PHASES.has(nextPhase)) {
+    return false;
+  }
+  return !existsSync(sourceDirectory);
+}
 
 const defaultOptions: SwaggerOptions = {
   apiFolder: 'pages/api',
@@ -41,6 +85,7 @@ export function createSwaggerSpec({
   apiFolder = 'pages/api',
   schemaFolders = [],
   autoDoc = false,
+  scanBuildOutput,
   ...swaggerOptions
 }: SwaggerOptions = defaultOptions) {
   const scanFolders = [apiFolder, ...schemaFolders];
@@ -49,17 +94,27 @@ export function createSwaggerSpec({
     const apiDirectory = join(process.cwd(), folder);
     const publicDirectory = join(process.cwd(), 'public');
     const fileTypes = ['ts', 'tsx', 'jsx', 'js', 'json', 'swagger.yaml'];
-    return [
+    const paths = [
       ...fileTypes.map((fileType) => `${apiDirectory}/**/*.${fileType}`),
-      // Only scan build directory for *.swagger.yaml and *.js files
-      ...['js', 'swagger.yaml', 'json'].map(
-        (fileType) => `${buildApiDirectory}/**/*.${fileType}`
-      ),
       // Support load static files from public directory
       ...['swagger.yaml', 'json'].map(
         (fileType) => `${publicDirectory}/**/*.${fileType}`
       ),
     ];
+    if (
+      shouldScanBuildDirectory({
+        sourceDirectory: apiDirectory,
+        buildDirectory: buildApiDirectory,
+        scanBuildOutput,
+      })
+    ) {
+      paths.push(
+        ...['js', 'swagger.yaml', 'json'].map(
+          (fileType) => `${buildApiDirectory}/**/*.${fileType}`
+        )
+      );
+    }
+    return paths;
   });
 
   // Append base path server element to server array

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { createSwaggerSpec, extractApiInfo } from '../src';
+import {
+  createSwaggerSpec,
+  extractApiInfo,
+  shouldScanBuildDirectory,
+} from '../src';
 
 describe('withSwagger', () => {
   it('should create default swagger json option', () => {
@@ -156,5 +163,78 @@ describe('withSwagger', () => {
 
   it('ignores a missing App Router directory', () => {
     expect(extractApiInfo('test/fixtures/missing')).toEqual([]);
+  });
+});
+
+describe('shouldScanBuildDirectory', () => {
+  it('skips missing build directories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-scan-'));
+    try {
+      expect(
+        shouldScanBuildDirectory({
+          sourceDirectory: join(root, 'app/api'),
+          buildDirectory: join(root, '.next/server/app/api'),
+        })
+      ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips .next during Next.js production builds', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-scan-'));
+    try {
+      mkdirSync(join(root, 'app/api'), { recursive: true });
+      mkdirSync(join(root, '.next/server/app/api'), { recursive: true });
+      expect(
+        shouldScanBuildDirectory({
+          sourceDirectory: join(root, 'app/api'),
+          buildDirectory: join(root, '.next/server/app/api'),
+          nextPhase: 'phase-production-build',
+        })
+      ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('scans compiled output when the source folder is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-scan-'));
+    try {
+      mkdirSync(join(root, '.next/server/app/api'), { recursive: true });
+      expect(
+        shouldScanBuildDirectory({
+          sourceDirectory: join(root, 'app/api'),
+          buildDirectory: join(root, '.next/server/app/api'),
+        })
+      ).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('honors an explicit scanBuildOutput flag', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-scan-'));
+    try {
+      mkdirSync(join(root, 'app/api'), { recursive: true });
+      mkdirSync(join(root, '.next/server/app/api'), { recursive: true });
+      expect(
+        shouldScanBuildDirectory({
+          sourceDirectory: join(root, 'app/api'),
+          buildDirectory: join(root, '.next/server/app/api'),
+          scanBuildOutput: true,
+          nextPhase: 'phase-production-build',
+        })
+      ).toBe(true);
+      expect(
+        shouldScanBuildDirectory({
+          sourceDirectory: join(root, 'missing'),
+          buildDirectory: join(root, '.next/server/app/api'),
+          scanBuildOutput: false,
+        })
+      ).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stop globbing `.next/server` while Next.js is compiling. That walk can fail Vercel builds with:

```
ENOENT: no such file or directory, lstat '.../.next/export-detail.json'
```

Source API files and `public` OpenAPI files are scanned instead. Compiled output is used only when the source folder is missing (standalone/runtime), or when `scanBuildOutput: true`.

Stack:

1. #1245 — `AGENTS.md`
2. **#1248** (this PR) — Vercel/Next `.next` scan (#1157)
3. #1247 — standalone spec
4. #1246 — swagger-ui-react Strict Mode

Base: `cursor/agents-md-69d3` (#1245).

Fixes #1157
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a028c9-ff0a-7dfb-a2d7-7f05834e69d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

