### PR TITLE
docs: sync AGENTS.md with Next 16 example and pnpm 10.34.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,15 @@ Instructions for AI coding agents working on `next-swagger-doc`.
 
 Generate an OpenAPI (Swagger) spec from Next.js API routes. JSDoc `@swagger` blocks are parsed by `swagger-jsdoc`. App Router `route.ts` files can also get basic operations from folder paths and exported HTTP handlers when `autoDoc` is enabled.
 
-- Runtime: Node.js >= 18
-- Package manager: pnpm 10.9.0 (Corepack)
+- Runtime: Node.js >= 18 (Next.js 16 example apps need Node.js >= 20.9)
+- Package manager: pnpm 10.34.5 (Corepack)
 - Language: TypeScript (strict, ESM)
 
 ## Setup
 
 ```sh
 corepack enable
-corepack pnpm@10.9.0 install --frozen-lockfile
+corepack pnpm@10.34.5 install --frozen-lockfile
 ```
 
 `.agents/setup` runs the same install. No extra services need to be started.
@@ -39,7 +39,7 @@ Use Vitest for tests. Prefer real fixtures under `test/fixtures` over mocks.
 - `src/cli.ts` — `next-swagger-doc-cli`
 - `src/index.ts` — public exports
 - `test/` — Vitest tests and snapshots
-- `examples/` — Next.js 13/14/15 demo apps (separate lockfiles)
+- `examples/` — Next.js 13/14/15/16 demo apps (separate lockfiles)
 
 Do not edit `dist/`; pkgroll writes it from `src/`.
 
@@ -59,3 +59,5 @@ Do not edit `dist/`; pkgroll writes it from `src/`.
 ## Examples
 
 Example apps depend on published `next-swagger-doc`. Library changes are verified with `pnpm test` in the repo root, not by rewriting example lockfiles unless the task is specifically about an example.
+
+Keep the versioned folders on their Next.js lines (`next13-simple`, `next14-app`, `next15-app`, `next16-app`). Do not bump 13/14/15 examples to 16.


### PR DESCRIPTION
## What

Update `AGENTS.md` so agent setup matches current `main`.

## Why

Commits in the last 24 hours drifted from this file:

- `5b300bf` feat: add Next.js 16 example app (#1253) — README lists `examples/next16-app`, but AGENTS.md still said 13/14/15 only
- `426aa41` fix(deps): update all non-major dependencies (#1201) — `packageManager` is `pnpm@10.34.5`, AGENTS.md still told agents to install `pnpm@10.9.0`

Skipped: vite/next security pins (#1251, #1252, #1234), GitHub Action pins (#1239), and CHANGELOG (Changie-generated). README already documents the Next 16 example.

## How

- Pin Corepack/pnpm instructions to 10.34.5
- List Next.js 13/14/15/16 example apps
- Note Node 20.9+ for Next 16 samples and keep versioned example folders on their lines

Please review for accuracy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance to require Node.js 18 or newer.
  * Documented Node.js 20.9+ for Next.js 16 examples.
  * Updated the recommended Corepack pnpm version.
  * Added Next.js 16 to the layout documentation and clarified version-specific example guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->