### PR TITLE
docs: refresh codebase map to current templates

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,88 +1,207 @@
-# ARCHITECTURE — next-swagger-doc
+# Architecture
 
-## Overview
+**Analysis Date:** 2026-08-26
 
-A small, dependency-light library with **three public surfaces**:
+## Pattern Overview
 
-1. `createSwaggerSpec()` — build an OpenAPI 3 spec object from JSDoc-annotated route files
-2. `withSwagger()` — Next.js API-route middleware that serves the spec as JSON
-3. `next-swagger-doc-cli` — CLI that reads a JSON config and writes `swagger.json`
+**Overall:** Stateless facade + pipeline over `swagger-jsdoc`, with an optional App Router auto-doc overlay.
 
-Plus a newer **App Router auto-doc** feature that derives basic operations from `route.ts` files without any annotations.
+**Key Characteristics:**
+- Library, not a framework: `createSwaggerSpec` in `src/swagger.ts` is a pure (cwd/env/fs-dependent) function that returns an OpenAPI 3 document; there is no long-lived process, cache, or DI container.
+- Dual documentation sources: JSDoc `@swagger` blocks parsed by `swagger-jsdoc`, plus optional `autoDoc` operations derived from App Router `route.*` files (`src/auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`). Manual JSDoc operations win on conflict via `src/merge-auto-doc.ts`.
+- Build-aware file discovery: `src/spec-source.ts` maps source folders to `.next/server/<folder>` compiled output and `public/`. `shouldScanBuildDirectory` in `src/swagger.ts` refuses to glob `.next` during Next.js production phases (`NEXT_PHASE`) to avoid Vercel `export-detail.json` ENOENT failures.
 
 ## Layers
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Entry: src/index.ts (re-exports public API)                │
-├─────────────────────────────────────────────────────────────┤
-│  src/swagger.ts     — spec creation + Next.js middleware    │
-│  src/auto-doc.ts    — App Router route scanner + generator  │
-│  src/route-parser.ts — route source parsing (es-module-lexer) │
-│  src/cli.ts         — CLI binary (cleye)                    │
-├─────────────────────────────────────────────────────────────┤
-│  swagger-jsdoc    — parses JSDoc annotations → OAS3 spec    │
-│  node:fs / node:path — filesystem scanning                  │
-└─────────────────────────────────────────────────────────────┘
-```
+**Public API:**
+- Purpose: Re-export the functions and types consumers import from `next-swagger-doc`.
+- Location: `src/index.ts`
+- Contains: Re-exports of `src/auto-doc.ts` (`extractApiInfo`, `generateAutoDoc`, `ApiInfo`) and `src/swagger.ts` (`createSwaggerSpec`, `withSwagger`, `SwaggerOptions`, `loadSpecFile`, `isAutoDocEnabled`, `shouldScanBuildDirectory`).
+- Depends on: `src/auto-doc.ts`, `src/swagger.ts`
+- Used by: npm package consumers, example apps under `examples/`, tests in `test/index.test.ts`
 
-## Core Modules
+**Orchestration:**
+- Purpose: Assemble glob lists, invoke `swagger-jsdoc`, optionally overlay auto-doc, and persist or return the spec.
+- Location: `src/swagger.ts`
+- Contains: `SwaggerOptions` / `AutoDocOptions` types, `createSwaggerSpec`, `withSwagger`, `loadSpecFile`, `isAutoDocEnabled`, `shouldScanBuildDirectory`, `NEXT_BUILD_PHASES`.
+- Depends on: `swagger-jsdoc`, `next` types (`NextApiRequest`/`NextApiResponse`), `src/auto-doc.ts`, `src/merge-auto-doc.ts`, `src/spec-source.ts`, Node `fs`/`path`.
+- Used by: `src/index.ts`, `src/cli.ts`, `examples/next13-simple/pages/api/doc.ts` (`withSwagger`), `examples/*/lib/swagger.ts` (`createSwaggerSpec`).
 
-### `src/swagger.ts` — public API
+**Spec source discovery:**
+- Purpose: Own the Next.js layout mapping so glob and auto-doc walkers do not re-derive `.next/server` or `public/` paths.
+- Location: `src/spec-source.ts`
+- Contains: `SpecLocations` (`sourceDirs`, `buildDirs`, `publicDir`) and `discoverSpecLocations`.
+- Depends on: Node `path` only.
+- Used by: `src/swagger.ts` (JSDoc globs), `src/auto-doc.ts` (route file walk).
 
-- **`SwaggerOptions`** = swagger-jsdoc `Options` + `apiFolder` (default `'pages/api'`), `schemaFolders` (default `[]`), `definition` (required `OAS3Definition`), `outputFile`, `specFile`, `scanBuildOutput`, `autoDoc` (`boolean | AutoDocOptions`)
-- **`createSwaggerSpec()`**
-  1. If `specFile` exists, returns that JSON document (standalone build-time path)
-  2. Builds a glob list of `apis` from `apiFolder` + `schemaFolders`: source dir (`**/*.{ts,tsx,jsx,js,json,swagger.yaml}`), `public/` (swagger.yaml/json), and `.next/server` only when `shouldScanBuildDirectory` says so
-  3. Injects a `servers` entry from `process.env.__NEXT_ROUTER_BASEPATH` if a base path is set and no `servers` are defined
-  4. Delegates to `swaggerJsdoc(options)` for the base spec
-  5. If `isAutoDocEnabled` (explicit on, or source folder missing unless `autoDoc: false`), merges generated paths — **manual `@swagger` operations win**
-  6. Optionally writes `outputFile`
-- **`shouldScanBuildDirectory()`** — skips `.next` while `NEXT_PHASE` is a production build/export (Vercel `export-detail.json` ENOENT). Compiled output is a runtime fallback when source is gone, or when `scanBuildOutput: true`.
-- **`withSwagger()`** — returns a Next.js API handler; wraps `createSwaggerSpec` in try/catch, sends `200` + spec or `400` + `{ error }`
+**Auto-doc pipeline:**
+- Purpose: Infer OpenAPI paths and HTTP methods from App Router `route` files when JSDoc is absent or incomplete.
+- Location: `src/auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/merge-auto-doc.ts`
+- Contains: recursive `route.*` discovery; `es-module-lexer` export parsing; Next.js folder-to-OpenAPI path translation; per-method merge where manual operations win.
+- Depends on: `es-module-lexer` (`src/route-parser.ts`), `src/spec-source.ts`, Node `fs`/`path`.
+- Used by: `createSwaggerSpec` in `src/swagger.ts`; unit tests in `test/index.test.ts`.
 
-### `src/auto-doc.ts` — App Router scanner (newest feature)
+**JSDoc OpenAPI parser (external):**
+- Purpose: Parse `@swagger` YAML/JSON comments and YAML/JSON schema files into an OAS3 document.
+- Location: dependency `swagger-jsdoc` (invoked from `src/swagger.ts`)
+- Contains: Glob matching and JSDoc annotation extraction. Not vendored in this repo.
+- Depends on: file globs produced by `createSwaggerSpec`.
+- Used by: `createSwaggerSpec` as the first spec body, before auto-doc merge.
 
-- **`extractApiInfo(apiFolder, cwd)`** — walks the folder recursively, finds `route.*` files (ts/tsx/js/jsx/mts/mtsx/mjs/mjsx), reads exported HTTP methods, converts directory segments to OpenAPI path segments, and returns sorted `{ path, methods }[]`. Scans both the source folder and `.next/server/<apiFolder>` (compiled `route.js` files) when present.
-- **`generateAutoDoc(apiInfos)`** — builds minimal operations: `summary` (`"GET /path"`), path `parameters` from `{...}` segments, and a default `200` "Successful response".
-- **Internal helpers**:
-  - `getRouteFiles()` — recursive directory walk
-  - `getApiSegments()` — strips everything up to the `app`/`pages` root to derive the API base path
-  - `toOpenApiPaths()` — converts `[id]` → `{id}`, `[...slug]` → `{slug}`, `[[...slug]]` → optional catch-all (emits both with and without the segment), drops route groups `(…)` and `@` parallel-route segments
-  - `getPathParameters()` — regex-extracts `{param}` from a path
+**CLI:**
+- Purpose: Generate a static `swagger.json` at build time from a JSON config file.
+- Location: `src/cli.ts` (published bin `next-swagger-doc-cli` → `dist/cli.js`)
+- Contains: `cleye` argv parser (`<config file>`, `--output` defaulting to `public/swagger.json`), `JSON.parse` of the config, `createSwaggerSpec`, `writeFileSync`.
+- Depends on: `src/swagger.ts`, `cleye`.
+- Used by: README Usage #4, standalone/Vercel `output: 'standalone'` workflow, `examples/next13-simple/next-swagger-doc.json`.
 
-### `src/route-parser.ts` — route source parser
+**Example consumers (not library internals):**
+- Purpose: Demonstrate Pages Router and App Router integration, including Swagger UI / Stoplight Elements viewers.
+- Location: `examples/next13-simple/`, `examples/next14-app/`, `examples/next15-app/`, `examples/next16-app/`
+- Contains: Next.js apps with their own lockfiles; they depend on published `next-swagger-doc`, not the local `src/` tree.
+- Depends on: published package + `swagger-ui-react` (and `@stoplight/elements` in next13-simple).
+- Used by: documentation and manual demos; library correctness is verified by `pnpm test` at the repo root, not by rewriting example lockfiles.
 
-- **`getExportedMethods(source)`** — extracts exported HTTP method handler names from a route module's source using **es-module-lexer** (`initSync` + `parse`). Handles comments, strings, and regex literals correctly; a per-file parse failure warns and returns `[]` rather than crashing doc generation.
-- **`HTTP_METHODS`** — the ordered list of HTTP methods a route can export (shared with `auto-doc.ts`).
-
-### `src/cli.ts` — CLI
-
-- Uses `cleye` to parse `<config file>` (required positional) and `--output` (default `public/swagger.json`)
-- Reads the JSON config, calls `createSwaggerSpec`, writes pretty-printed JSON
+**Tests:**
+- Purpose: Snapshot and unit-cover orchestration, auto-doc, merge, scan policy, and standalone spec I/O using real fixtures.
+- Location: `test/index.test.ts`, `test/fixtures/`, `test/__snapshots__/index.test.ts.snap`
+- Contains: Vitest `describe` blocks for `createSwaggerSpec`, `extractApiInfo`, `shouldScanBuildDirectory`, `isAutoDocEnabled`, `routeToOpenApiPaths`, `discoverSpecLocations`, `mergeAutoDoc`.
+- Depends on: public exports from `src/index.ts` plus internal modules `src/merge-auto-doc.ts`, `src/route-path.ts`, `src/spec-source.ts`.
+- Used by: `pnpm test` / Vitest.
 
 ## Data Flow
 
-**Manual (JSDoc) path:**
-```
-route files with @swagger comments ──► swagger-jsdoc ──► spec.paths (from annotations)
-```
+**createSwaggerSpec (primary generation):**
+1. If `specFile` is set, `loadSpecFile` in `src/swagger.ts` reads the JSON; on hit, return immediately (standalone runtime path; no route scan).
+2. Collect scan folders: `apiFolder` (default `pages/api`) plus `schemaFolders`.
+3. `discoverSpecLocations` in `src/spec-source.ts` maps each folder to `cwd/<folder>`, `cwd/.next/server/<folder>`, and `cwd/public`.
+4. Build `swagger-jsdoc` `apis` globs: source `**/*.{ts,tsx,jsx,js,json,swagger.yaml}`, public `**/*.{swagger.yaml,json}`, and compiled `**/*.{js,swagger.yaml,json}` only when `shouldScanBuildDirectory` is true.
+5. Clone `definition`; if `process.env.__NEXT_ROUTER_BASEPATH` is set and `definition.servers` is missing, inject a single `servers` entry with that URL.
+6. Call `swaggerJsdoc(options)` to parse JSDoc `@swagger` comments into an `OAS3Definition`.
+7. If `isAutoDocEnabled(autoDoc, !existsSync(source apiFolder))`, run `extractApiInfo` → `generateAutoDoc` → `mergeAutoDoc(autoPaths, spec.paths)` so generated operations fill gaps and manual operations win per HTTP method.
+8. If `outputFile` is set, `mkdirSync` + `writeFileSync` pretty-printed JSON, then return the in-memory spec.
 
-**Auto-doc path:**
-```
-route.ts files ──► extractApiInfo (paths + methods)
-            ──► generateAutoDoc (basic operations)
-            ──► merged into spec.paths (manual overrides generated)
-```
+**withSwagger (Pages Router API handler):**
+1. `withSwagger(options)` in `src/swagger.ts` returns a Next.js Pages API factory `() => (req, res) => ...`.
+2. On each request, call `createSwaggerSpec` with the captured options.
+3. `res.status(200).send(swaggerSpec)` on success; catch and `res.status(400).json({ error })` on failure.
+4. Consumed as `export default swaggerHandler()` in `examples/next13-simple/pages/api/doc.ts`.
 
-**Runtime serving:**
-```
-createSwaggerSpec ──► withSwagger handler ──► GET /api/doc → JSON spec
-```
+**CLI (build-time file generation):**
+1. `src/cli.ts` parses `next-swagger-doc-cli <config file> [--output public/swagger.json]` via `cleye`.
+2. Read and `JSON.parse` the config as `SwaggerOptions`.
+3. `createSwaggerSpec(config)` (which may also write `outputFile` from the config).
+4. Always `writeFileSync(argv.flags.output, JSON.stringify(spec, null, 2))`. Default output is `public/swagger.json`.
 
-## Key Design Decisions
+**autoDoc extraction:**
+1. `extractApiInfo(apiFolder)` in `src/auto-doc.ts` discovers existing `sourceDirs` and `buildDirs`.
+2. Recursively collect files named `route.{ts,tsx,js,jsx,mts,mtsx,mjs,mjsx}`.
+3. Relative directory segments (minus the filename) go to `routeToOpenApiPaths` in `src/route-path.ts`, which strips `app`/`pages` roots, drops route groups `(…)` and parallel `@…` segments, maps `[id]` / `[...slug]` / `[[...slug]]` to `{param}` (optional catch-alls emit two paths).
+4. `getExportedMethods` in `src/route-parser.ts` uses `es-module-lexer` `parse()` to find exported `GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`HEAD`/`OPTIONS`; comments, strings, and regex literals are ignored (see `test/fixtures/app/commented/route.ts`, `test/fixtures/app/api/regex/route.ts`, `test/fixtures/app/users/route.ts`).
+5. Methods are unioned per OpenAPI path, sorted, and filtered to those with at least one method.
+6. `generateAutoDoc` emits `{ summary, parameters from `{name}` path tokens, responses: { 200: Successful response } }`.
+7. `mergeAutoDoc` in `src/merge-auto-doc.ts` unions path keys and per-path operations: `{ ...generated, ...manual }` so a JSDoc `@swagger` GET replaces the generated GET but leaves generated PATCH/DELETE (see `test/fixtures/app/api/manual/route.ts` vs `test/fixtures/app/api/users/[id]/route.ts`).
 
-- **Real lexer over string matching** — auto-doc extracts exported handlers with es-module-lexer (a real ESM lexer) instead of the previous hand-rolled string scanner; comments, strings, and regex literals no longer cause false positives or misses
-- **Source first, compiled fallback** — do not glob `.next` during `next build`; scan compiled output only when the source folder is missing or `scanBuildOutput` is true
-- **Manual-over-generated precedence** — `{ ...generatedOperations, ...operations }` merge ensures hand-written docs are never clobbered
-- **Dual ESM/CJS output** via pkgroll with a single `src/` source of truth
+**Standalone / Vercel constraints:**
+1. During `phase-production-build` / `phase-production-compile` / `phase-export`, `shouldScanBuildDirectory` returns false unless `scanBuildOutput === true`.
+2. When source `apiFolder` is missing at runtime (`output: 'standalone'`), `isAutoDocEnabled` defaults on unless `autoDoc: false`, and compiled `route.js` under `.next/server` can still document paths/methods (JSDoc is stripped). Fixture: `test/fixtures/.next/server/app/only-compiled/compiled/route.js`.
+3. Preferred standalone path: generate at build (`CLI --output` or `outputFile`) and load via `specFile: 'public/swagger.json'` as in `examples/next14-app/lib/swagger.ts`.
+
+**State Management:**
+- No in-process state, cache, or singleton beyond `es-module-lexer` `initSync()` at module load in `src/route-parser.ts`.
+- All paths resolve against `process.cwd()` (`resolveUserPath`, `discoverSpecLocations`).
+- Environment: `NEXT_PHASE` gates `.next` globbing; `__NEXT_ROUTER_BASEPATH` optionally injects `servers`.
+- Specs are immutable return values; `outputFile` / CLI writes are side effects after generation.
+
+## Key Abstractions
+
+**SwaggerOptions:**
+- Purpose: Extends `swagger-jsdoc` `Options` with Next.js-specific knobs: `apiFolder`, `schemaFolders`, required `definition`, `outputFile`, `specFile`, `autoDoc`, `scanBuildOutput`.
+- Examples: `src/swagger.ts`, `examples/next13-simple/next-swagger-doc.json`, `examples/next16-app/lib/swagger.ts`
+- Pattern: Options object / configuration object passed through the facade.
+
+**SpecLocations:**
+- Purpose: Triple of directories where documentation can live for a given logical folder.
+- Examples: `src/spec-source.ts`
+- Pattern: Value object returned by `discoverSpecLocations(folders, cwd)`.
+
+**ApiInfo:**
+- Purpose: One OpenAPI path plus the lowercase HTTP methods exported by matching route files.
+- Examples: `src/auto-doc.ts`, asserted in `test/index.test.ts` against `test/fixtures/app/`
+- Pattern: Intermediate DTO between filesystem extraction and OpenAPI path objects.
+
+**PathsObject merge:**
+- Purpose: Union auto-generated and JSDoc path items with per-method precedence (manual wins).
+- Examples: `src/merge-auto-doc.ts`
+- Pattern: Shallow merge of path keys, then `{ ...autoOperations, ...manualOperations }` per path.
+
+**Route path translation:**
+- Purpose: Encode all Next.js App/Pages folder conventions in one place.
+- Examples: `src/route-path.ts`
+- Pattern: Pure function `routeToOpenApiPaths(apiFolder, routeSegments) → string[]`.
+
+**Export method parsing:**
+- Purpose: Detect HTTP handler exports without regex/string matching that would misread comments or regex literals.
+- Examples: `src/route-parser.ts`
+- Pattern: WASM lexer (`es-module-lexer`) + allowlist `HTTP_METHODS`.
+
+**OAS3Definition:**
+- Purpose: The OpenAPI 3 document returned to callers and written to disk.
+- Examples: produced by `swagger-jsdoc` in `src/swagger.ts`; snapshotted in `test/__snapshots__/index.test.ts.snap`; stored in `examples/next13-simple/public/swagger.json`
+- Pattern: External schema type from `swagger-jsdoc`; this library does not re-model OpenAPI.
+
+## Entry Points
+
+**Package barrel:**
+- Location: `src/index.ts`
+- Triggers: `import { createSwaggerSpec, withSwagger } from 'next-swagger-doc'` (resolved via `package.json` `exports` to `dist/index.js` / `dist/index.cjs`).
+- Responsibilities: Re-export public API; does not re-export `mergeAutoDoc`, `routeToOpenApiPaths`, `discoverSpecLocations`, or `getExportedMethods`.
+
+**createSwaggerSpec:**
+- Location: `src/swagger.ts`
+- Triggers: App Router `lib/swagger.ts` helpers (`examples/next14-app/lib/swagger.ts`, `examples/next15-app/lib/swagger.ts`, `examples/next16-app/lib/swagger.ts`); Pages `getStaticProps` (`examples/next13-simple/pages/api-doc.tsx`); CLI; `withSwagger`.
+- Responsibilities: Spec-file short-circuit, glob assembly, JSDoc parse, auto-doc merge, optional write.
+
+**withSwagger:**
+- Location: `src/swagger.ts`
+- Triggers: Pages Router API routes such as `examples/next13-simple/pages/api/doc.ts`.
+- Responsibilities: Per-request spec generation and JSON HTTP response with try/catch.
+
+**next-swagger-doc-cli:**
+- Location: `src/cli.ts` (bin `next-swagger-doc-cli` in `package.json`)
+- Triggers: `npx next-swagger-doc-cli next-swagger-doc.json [--output public/swagger.json]` (README Usage #4).
+- Responsibilities: Load JSON config, generate spec, write output file.
+
+**Example App Router docs page:**
+- Location: `examples/next14-app/app/api-doc/page.tsx` (mirrored in next15/next16)
+- Triggers: Next.js App Router navigation to `/api-doc`.
+- Responsibilities: Server-render `getApiDocs()` then pass the spec to client-only `react-swagger.tsx` (`next/dynamic`, `ssr: false`).
+
+**Example Pages viewers:**
+- Location: `examples/next13-simple/pages/api-doc.tsx`, `examples/next13-simple/pages/swagger.tsx`, `examples/next13-simple/pages/playground.tsx`
+- Triggers: Next.js Pages routes `/api-doc`, `/swagger`, `/playground`.
+- Responsibilities: Static generation via `createSwaggerSpec`, or load prebuilt `/swagger.json` into swagger-ui-react / Stoplight Elements.
+
+## Error Handling
+
+**Strategy:** Fail closed at the HTTP boundary; skip unparsable route files during auto-doc; let JSON/fs errors bubble in CLI and `createSwaggerSpec` except where a missing `specFile` is treated as a fallback.
+
+**Patterns:**
+- `withSwagger` wraps `createSwaggerSpec` in try/catch and returns HTTP 400 with `error.message` or `'Failed to create Swagger spec'` (`src/swagger.ts`).
+- `getExportedMethods` catches `es-module-lexer` parse failures, `console.warn`s `next-swagger-doc: failed to parse route source (<file>), skipping file`, and returns `[]` so one bad `route` file does not abort the spec (`src/route-parser.ts`).
+- `loadSpecFile` returns `undefined` when the file is missing so callers fall back to scanning; a present but invalid JSON still throws from `JSON.parse`.
+- `extractApiInfo` ignores missing directories (`existsSync` filter); a missing `apiFolder` yields `[]` (tested in `test/index.test.ts`).
+- CLI does not catch: invalid config JSON or write failures abort the process.
+- No custom error types; `Error` instances and Node exceptions only.
+
+## Cross-Cutting Concerns
+
+**Logging:** Minimal. `src/route-parser.ts` uses `console.warn` for unparsable route sources. `src/cli.ts` `console.log`s the target output path and raw config. No structured logger, log levels, or tracing.
+
+**Validation:** Compile-time TypeScript (`strict` in `tsconfig.json`; `SwaggerOptions` requires `definition: OAS3Definition`). Runtime: HTTP method allowlist in `src/route-parser.ts`; `swagger-jsdoc` validates/assembles OpenAPI from JSDoc. No Zod/JSON-schema validation of `SwaggerOptions` or of generated operations. Biome lints `src/` (`biome.json`, 2-space, 80 columns).
+
+**Authentication:** The library does not authenticate callers. It forwards OpenAPI `components.securitySchemes` and `security` from user `definition` (Bearer and OAuth2 covered by snapshots in `test/index.test.ts` and example `lib/swagger.ts` files). `withSwagger` handlers are unauthenticated JSON endpoints.
+
+---
+
+*Architecture analysis: 2026-08-26*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,42 +1,251 @@
-# CONCERNS — next-swagger-doc
+# Codebase Concerns
 
-## Parsing (previously the highest risk)
+**Analysis Date:** 2026-08-26
 
-- **Resolved**: the hand-rolled source scanner (`sanitizeSource()` + string matching in `getExportedMethods`) was replaced with **es-module-lexer** (`src/route-parser.ts`) — a real ESM lexer that handles comments, strings, and regex literals correctly. The old approach silently missed handlers when source contained regex literals with comment-like sequences; a regression fixture (`test/fixtures/app/api/regex/route.ts`) now guards this.
-- **Remaining**: `getApiSegments()` uses `lastIndexOf('app')` / `lastIndexOf('pages')` on the folder path — a folder named `myapp`, `pages2`, or a parent dir containing "app"/"pages" would be mis-split
-- **Regex-based path parameter extraction** (`getPathParameters`) — fine for simple `{id}` but won't handle path parameters with regex constraints or multi-segment patterns
+## Tech Debt
 
-## Versioning / Release Hygiene
+**Unused `isarray` runtime dependency:**
+- Issue: `isarray@2.0.5` is declared in the library `dependencies` and again in `examples/next13-simple`, but no source file imports it. It is leftover install-time noise (also listed in `cspell-tool.txt` / `next-swagger-doc.txt`).
+- Files: `package.json`, `examples/next13-simple/package.json`, `src/`
+- Impact: Extra install surface; confuses audits (`npm ls`) and security scanners.
+- Fix approach: Remove from both package.json files and the lockfiles unless a real import is added.
 
-- `package.json` is at **`0.4.2-0`** (prerelease) but `CHANGELOG.md` stops at **0.3.4 (2022)** — changelog is 4 minor versions behind
-- `.changes/unreleased/` is empty (only `.gitkeep`) — no change fragments for the new App Router feature (PR #1241) or any other unreleased work
-- `next-swagger-doc.txt` is a **cspell dictionary**, not documentation, despite the name
+**Example apps pin a GitHub beta tag, not the local 0.5.0 package:**
+- Issue: All four examples depend on `next-swagger-doc`: `github:jellydn/next-swagger-doc#v0.4.2-beta.0` while the repo is `0.5.0`. `examples/next13-simple/link.config.json` additionally points at `../` for `npx link`, so two conflicting linking strategies exist. App Router examples also set `specFile: 'public/swagger.json'` but those `public/` folders have no `swagger.json` (only `examples/next13-simple/public/swagger.json` exists). `examples/next15-app/package.json` still names the package `"next13-app"`. Example READMEs for 14/15 are leftover shadcn/create-next-app boilerplate.
+- Files: `examples/next13-simple/package.json`, `examples/next13-simple/link.config.json`, `examples/next14-app/package.json`, `examples/next14-app/lib/swagger.ts`, `examples/next14-app/README.md`, `examples/next15-app/package.json`, `examples/next15-app/lib/swagger.ts`, `examples/next16-app/package.json`, `examples/next16-app/lib/swagger.ts`, `AGENTS.md`
+- Impact: `pnpm dev` in examples does not exercise unpublished library changes (AGENTS.md already says this). `specFile` is dead config until a CLI generate step exists. Copy-paste naming (`next13-app`) misleads contributors.
+- Fix approach: Keep examples on published tags by policy, but bump them to `0.5.0` after release; add a generate script or drop unused `specFile`; rename `next15-app`; replace boilerplate READMEs.
 
-## Config / Tooling Drift
+**Default `apiFolder` is still Pages Router:**
+- Issue: `createSwaggerSpec` / `withSwagger` default `apiFolder` to `'pages/api'`. App Router apps must pass `'app/api'`. `autoDoc` is off when source exists unless set `true`. GitHub issue #1199 (`paths is empty`) is the resulting empty spec. JSDoc comments on `createSwaggerSpec` still document non-options (`openApiVersion`, `title`, `version`).
+- Files: `src/swagger.ts`, `README.md`, `src/index.ts`
+- Impact: Next 13+ App Router users following Usage #3 / defaults get `paths: {}` unless they add JSDoc *and* the right folder. README Usage #1 is labeled “Next.js 13” even though Next 16 examples exist.
+- Fix approach: Keep the Pages default for compatibility, but document App Router first; consider warning when `pages/api` is missing and `app/api` exists.
 
-- `size-limit` is a devDependency but has **no config file** and no script — dead dependency
-- `tsconfig.json` includes a `types/` directory that **does not exist** (harmless, but stale)
-- `c8` and `@vitest/coverage-v8` both present (overlapping coverage tooling)
-- `.swm/testing-overview.b1r1n.sw.md` references **Playwright E2E tests that don't exist** in the repo — misleading onboarding doc
-- `examples/next15-app/package.json` is named `"next13-app"` (copy-paste from the older example)
+**Placeholder docs and changelog gap:**
+- Issue: `SECURITY.md` is the unmodified GitHub template (claims support for `5.1.x` / `4.0.x`; this package is `0.5.0`). `CHANGELOG.md` jumps from `0.3.4` (2022) to `0.4.2-beta.0` / `0.5.0` (2026) and omits published `0.3.5`–`0.4.1` (0.4.1 is the Vercel ENOENT release, issue #1157).
+- Files: `SECURITY.md`, `CHANGELOG.md`, `package.json`
+- Impact: No real vulnerability-reporting process; historical breakages are invisible in-repo.
+- Fix approach: Replace the security template with a reporting contact and actual supported versions; backfill changelog from GitHub releases.
 
-## CI Gaps
+**Idle tooling and config drift:**
+- Issue: DevDependencies `c8`, `size-limit`, and `@skypack/package-check` have no scripts. `biome.json` `$schema` is `1.7.0` while Biome is `1.9.4`, and `linter.rules.recommended` is `false`. `tsconfig.json` `include`s `"types"` but no `types/` directory exists; `moduleResolution` is legacy `"node"` despite `"type": "module"`. Example `packageManager` is `pnpm@10.8.0` vs root `pnpm@10.34.5`. Tests under `describe('withSwagger')` call `createSwaggerSpec`, not `withSwagger`. CLI comment says `._.filePath` but the parameter is `configFile`.
+- Files: `package.json`, `biome.json`, `tsconfig.json`, `test/index.test.ts`, `src/cli.ts`, `examples/*/package.json`
+- Impact: Dead tooling in every install; weaker lint than Biome recommended; contributors copy the wrong test name when extending the handler API.
+- Fix approach: Drop unused devDeps, align Biome schema, fix tsconfig `include`, rename the snapshot describe block, fix the CLI comment.
 
-- **No CI workflow runs tests or lint** — only CodeQL and CodeSee workflows exist; regressions are caught only by pre-commit hooks (which require local install) and local `pnpm test`
-- CodeQL runs on every push/PR but there's no coverage or typecheck gate
+**`withSwagger` is a Pages-Router, per-request generator:**
+- Issue: The handler is typed with `NextApiRequest` / `NextApiResponse` and calls `createSwaggerSpec` on every request. GitHub issue #1190 asked for an App Router equivalent; the library still has none. Examples 14/15/16 generate the spec in a Server Component instead.
+- Files: `src/swagger.ts`, `examples/next13-simple/pages/api/doc.ts`, `examples/next14-app/app/api-doc/page.tsx`
+- Impact: App Router apps cannot drop in `withSwagger`. Runtime generation walks the filesystem on each `/api/doc` hit.
+- Fix approach: Add a Route Handler helper (or document `createSwaggerSpec` + `NextResponse.json` as the App pattern). Cache or generate at build via `outputFile` / CLI.
 
-## Potential Runtime Issues
+## Known Bugs
 
-- `extractApiInfo()` scans **both** the source folder and `.next/server/<apiFolder>` and merges results into a single map — if a route exists in both (stale build output), methods could be double-counted or a stale compiled route could surface a method that no longer exists in source
-- `swagger.ts` globs `**/*.{ts,tsx,jsx,js,json,swagger.yaml}` across the api folder — large folders or non-route files (helpers, types) get fed to swagger-jsdoc and could produce unexpected spec entries
-- `withSwagger` returns `400` on failure but does **not log** the error — silent failures in production are hard to diagnose
-- Base-path injection relies on the internal `process.env.__NEXT_ROUTER_BASEPATH` env var (Next.js internals) — could change between Next versions
+**`extractApiInfo` walks `.next/server` without the production-build gate:**
+- Symptoms: `createSwaggerSpec` gates swagger-jsdoc globs with `shouldScanBuildDirectory` (skips `NEXT_PHASE` `phase-production-build` / `phase-production-compile` / `phase-export` unless `scanBuildOutput: true`). `extractApiInfo` always `readdirSync`s every existing `buildDirs` entry and unions methods into the spec. Leftover compiled handlers can appear as extra operations; a `readdir`/`readFile` race while Next rewrites `.next` can throw ENOENT (same class of failure as issue #1157, though the original glob of `.next/export-detail.json` is the swagger-jsdoc path).
+- Files: `src/auto-doc.ts`, `src/swagger.ts`, `src/spec-source.ts`, `test/index.test.ts`, `test/fixtures/.next/server/app/api/compiled/route.js`
+- Trigger: `autoDoc: true` (README default for App Router) during `next build` when `.next/server/<apiFolder>` already exists, or a stale compiled `route.js` that exports a method the source no longer exports.
+- Workaround: Set `autoDoc: false` during build, or generate with CLI/`outputFile` and serve `specFile`. Do not set `scanBuildOutput: true` on Vercel (README already warns this re-enables `.next` globs).
 
-## Security
+**CLI does not create parent directories and has no error handling:**
+- Symptoms: `next-swagger-doc-cli … --output public/swagger.json` throws if `public/` is missing (`writeFileSync` only). Invalid JSON or a missing config file crash with an uncaught exception. If the JSON config itself contains `outputFile`, `createSwaggerSpec` may write that path *and* the CLI writes `--output`.
+- Files: `src/cli.ts`, `src/swagger.ts` (`outputFile` uses `mkdirSync`)
+- Trigger: Fresh repo with no `public/`; malformed `next-swagger-doc.json`; config `outputFile` plus `--output`.
+- Workaround: `mkdir -p public` first; keep a single output path.
 
-- No obvious vulnerabilities in the small codebase; CodeQL is configured. `noGlobalEval` is enforced. No user input is evaluated. The main risk surface is the parser being fed arbitrary source (low risk — the lexer never executes the code).
+**`withSwagger` reports generation failures as HTTP 400 and leaks `error.message`:**
+- Symptoms: Any `createSwaggerSpec` throw (bad glob, invalid YAML JSDoc, missing files mid-walk) becomes `400 { error: <Error.message> }`. That is a server-side failure, not a client input error, and the message can include filesystem paths.
+- Files: `src/swagger.ts`
+- Trigger: Call `GET` on a `withSwagger()` Pages route when spec generation throws.
+- Workaround: Prefer `createSwaggerSpec` at build / in a Server Component (App Router examples) so errors surface in the build log.
 
-## Performance
+**`loadSpecFile` is an unvalidated `JSON.parse`:**
+- Symptoms: A present but invalid `specFile` throws (caught only inside `withSwagger`). A JSON object that is not an OpenAPI document is returned as-is (`as OAS3Definition`), so UI pages show “Unable to render this definition” (issues #1163 / discussion #1164).
+- Files: `src/swagger.ts`
+- Trigger: Truncated or hand-edited `public/swagger.json`; empty `{}`.
+- Workaround: Generate the file with the CLI; omit `specFile` until the file exists (`loadSpecFile` already returns `undefined` when missing).
 
-- Trivial for typical API sizes. `extractApiInfo` does a full recursive directory walk and reads every route file synchronously (`readFileSync`) — fine for dev/docs generation, but the sync I/O could add up on very large route trees
-- `createSwaggerSpec` re-reads and re-parses everything on every call (no caching) — relevant if called per-request via `withSwagger` in production
+No `TODO` / `FIXME` / `HACK` / `XXX` markers were found under `src/`, `test/`, or `examples/`.
+
+## Security Considerations
+
+**Security policy is a GitHub stub:**
+- Risk: `SECURITY.md` still says “Use this section to tell people…” and lists fictional `5.1.x` / `4.0.x` support. There is no reporting address or SLA.
+- Files: `SECURITY.md`
+- Current mitigation: None beyond MIT LICENSE.
+- Recommendations: Name a contact (GitHub Security Advisories / email), list actually supported npm versions (`0.5.x`), and drop the template table.
+
+**Runtime spec generation reads the whole API tree and can ingest `public/**/*.json`:**
+- Risk: `createSwaggerSpec` globs `public/**/*.json` and `public/**/*.swagger.yaml` into swagger-jsdoc. Any JSON under `public/` is treated as an OpenAPI fragment. A large data dump or a secrets JSON accidentally placed in `public/` is merged into the served spec. `withSwagger` also returns raw `error.message` to the client (see Known Bugs).
+- Files: `src/swagger.ts`, `src/cli.ts`
+- Current mitigation: Intended for committed OpenAPI YAML/JSON (the next13 example uses `models/**/*.swagger.yaml` copied to `public/openapi`). Missing `specFile` is skipped.
+- Recommendations: Restrict public globs to `*.swagger.yaml` / a configured spec path; never glob all `*.json`; return 500 without `error.message` from `withSwagger`.
+
+**CLI writes whatever `--output` path the user passes:**
+- Risk: Expected for a local codegen CLI (no sandbox). Combined with `JSON.parse` of the config file, a bad config is fail-loud rather than fail-safe.
+- Files: `src/cli.ts`
+- Current mitigation: Config path is a required argv parameter; output defaults to `public/swagger.json`.
+- Recommendations: Validate config against `SwaggerOptions` (at least `definition.openapi` / `definition.info`); `mkdirSync` before write (same as `outputFile`).
+
+This library is a build/runtime doc generator, not an auth system. No credential handling exists in `src/`. Do not treat the empty `SECURITY.md` as evidence of a product security review.
+
+## Performance Bottlenecks
+
+**Synchronous full-tree scan on every `createSwaggerSpec` call:**
+- Problem: Each call `readdirSync`s the API tree, `readFileSync`s every `route.*` file, then swagger-jsdoc globs `ts/tsx/jsx/js/json/swagger.yaml` under source dirs plus `public/**`. `withSwagger` repeats that per HTTP request. There is no cache, etag, or incremental invalidation.
+- Files: `src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`
+- Cause: All I/O is sync Node fs; swagger-jsdoc glob is unbounded (`**/*`).
+- Improvement path: Generate once (`outputFile` / CLI) and load `specFile` at runtime (already the standalone path). If a live handler remains, memoize on `mtime` or `NODE_ENV === 'production'`.
+
+**Optional compiled-output glob can walk webpack/turbopack chunks:**
+- Problem: `scanBuildOutput: true` adds `.next/server/<folder>/**/*.{js,swagger.yaml,json}`. A real `.next/server` tree is large; globbing `**/*.js` is far more work than reading `route.js` files only.
+- Files: `src/swagger.ts`, `src/spec-source.ts`
+- Cause: File-type globs rather than `**/route.js`.
+- Improvement path: When scanning build output, only open files named `route.js` (same as `isRouteFile` on the source side). Keep the default “scan compiled only if source is missing and not compiling”.
+
+**`es-module-lexer` WASM `initSync()` at import time:**
+- Problem: `route-parser.ts` calls `initSync()` when the module loads, so any import of `next-swagger-doc` pays WASM init even if `autoDoc` is off. Combined with `node:fs`, the package cannot run on the Edge runtime.
+- Files: `src/route-parser.ts`, `src/swagger.ts`, `src/auto-doc.ts`
+- Cause: Lexer requires WASM before `parse()`.
+- Improvement path: Lazy-init inside `getExportedMethods`; document Node.js runtime only.
+
+## Fragile Areas
+
+**Hard-coded `.next/server/<folder>` layout:**
+- Files: `src/spec-source.ts`, `src/swagger.ts`
+- Why fragile: `discoverSpecLocations` always uses `join(cwd, '.next/server', folder)`. Custom `distDir`, Next.js standalone layout (`.next/standalone/…`), and future Turbopack output locations are invisible. `src/app/api` works only because `routeToOpenApiPaths` takes the segment after the last `app`/`pages` (`src/app/api` → `/api`); that heuristic breaks if a folder named `app` appears earlier in a non-Next path.
+- Safe modification: Keep all build-output path logic in `discoverSpecLocations`. Add an option (`distDir`) and tests that pass a fake layout, as `test/index.test.ts` already does for `test/fixtures`.
+- Test coverage: Source vs `.next/server/<apiFolder>` with a custom cwd is tested (`extractApiInfo('app/only-compiled', 'test/fixtures')`). Custom `distDir` is not.
+
+**Compiled-route fallback vs real Next emit:**
+- Files: `src/route-parser.ts`, `src/auto-doc.ts`, `test/fixtures/.next/server/app/only-compiled/compiled/route.js`, `test/fixtures/.next/server/app/api/compiled/route.js`, `README.md`
+- Why fragile: `getExportedMethods` uses `es-module-lexer`, which only sees ESM export specifiers. The compiled fixtures are hand-written `export function OPTIONS()`. Production Next `route.js` chunks are typically webpack/turbopack wrappers (`exports.GET = …` / runtime modules). README claims standalone runtime still documents compiled `route.js` handlers; that is unverified against a real `next build`. JSDoc is stripped from compiled output (documented).
+- Safe modification: Capture a real `next build` `route.js` as a fixture before changing the lexer. Consider a CJS export fallback (`exports.GET` / `module.exports.GET`) if standalone autoDoc is a supported path.
+- Test coverage: No fixture from an actual Next compile; `test/fixtures/.next/server/app/api/compiled/route.js` is never asserted by `extractApiInfo('test/fixtures/app')` because that call uses cwd-relative `.next/server/test/fixtures/app`, not `test/fixtures/.next`.
+
+**Next.js folder conventions concentrated in regex:**
+- Files: `src/route-path.ts`, `src/auto-doc.ts`
+- Why fragile: Route groups `(name)`, parallel `@slot`, `[id]`, `[...slug]`, `[[...slug]]` are string-replaced. Private folders (`_lib`) are **not** skipped (Next.js excludes them from routing). Catch-alls become a single `{slug}` string param, which does not express multi-segment paths in OpenAPI. Intercepting routes `(.)photo` happen to look like groups and are dropped; that is accidental. `isRouteFile` only matches `route.{ts,tsx,js,jsx,mts,mtsx,mjs,mjsx}` — Pages Router `pages/api/*.ts` never get autoDoc (JSDoc only).
+- Safe modification: Add fixtures for `_private`, intercepting `(.)`, and `src/app` before changing `routeToOpenApiPaths`. Keep JSDoc-wins merge in `merge-auto-doc.ts`.
+- Test coverage: Dynamic, catch-all, optional catch-all, groups, and `@parallel` are tested. Private `_` folders, intercepting routes, and Pages Router filenames are not.
+
+**JSDoc YAML is parsed by swagger-jsdoc, not this repo:**
+- Files: `src/swagger.ts` (`swaggerJsdoc(options)`), `test/fixtures/app/api/manual/route.ts`
+- Why fragile: Indentation/YAML errors in `@swagger` blocks fail inside swagger-jsdoc (`yaml@2.0.0-1`). Manual vs auto merge is only per HTTP method (`mergeAutoDoc`); path-level OpenAPI keys ride along on the manual object. `fileTypes` includes `swagger.yaml` but not `.yml` / `.yaml`.
+- Safe modification: Do not reimplement swagger-jsdoc parsing. Add a fixture `.yml` only if you expand `fileTypes`.
+- Test coverage: One manual `@swagger` GET that beats autoDoc. No invalid-YAML, `.yml`, or `schemaFolders` tests.
+
+**`NEXT_PHASE` set may lag Next.js:**
+- Files: `src/swagger.ts`
+- Why fragile: The skip list is `phase-production-build`, `phase-production-compile`, `phase-export`. Tests only pass `phase-production-build`. A new compile phase that is not in the set would glob `.next` again (issue #1157). `scanBuildOutput: true` overrides the skip even during those phases (documented, still dangerous on Vercel).
+- Safe modification: Keep the allow/deny logic only in `shouldScanBuildDirectory`. Never bypass it from `extractApiInfo`.
+- Test coverage: `phase-export` / `phase-production-compile` untested; autoDoc + `NEXT_PHASE` untested together.
+
+## Scaling Limits
+
+**Unbounded recursive walk of `apiFolder`:**
+- Current capacity: Fine for typical `app/api` trees (the test fixture is <10 routes). `extractApiInfo` and swagger-jsdoc both recurse with `**`.
+- Limit: If `apiFolder` is set to `.` or a monorepo root, swagger-jsdoc globs `./**/*.ts` (and `./**/*.json`) across the whole project, including `node_modules` if present under that tree. `getRouteFiles` has no ignore list. `withSwagger` does this on every request.
+- Scaling path: Refuse `apiFolder` outside known roots; ignore `node_modules` / `.git`; prefer CLI generate + `specFile` for large apps.
+
+**In-memory OpenAPI document, no pagination:**
+- Current capacity: One spec object built with `JSON.stringify(spec, null, 2)` for `outputFile` / CLI.
+- Limit: Thousands of operations plus `public/**/*.json` merges will block the event loop (all sync) and produce a multi-MB JSON payload for the browser UI.
+- Scaling path: Build-time generation; split specs by tag later if needed (not supported today).
+
+**Standalone / Vercel:**
+- Current capacity: Source scan works when `app/api` is on disk. Compiled fallback is best-effort (see Fragile). `specFile` short-circuits everything.
+- Limit: `output: 'standalone'` strips source (`README.md`, issue #1228). Without a prebuilt spec, runtime docs are empty or method-only.
+- Scaling path: Always generate `public/swagger.json` in CI/`postbuild` and set `specFile`.
+
+## Dependencies at Risk
+
+**`swagger-jsdoc@6.3.0` (engines Node `>=20`) vs library `engines.node: >=18`:**
+- Risk: Lockfile records `swagger-jsdoc@6.3.0` `engines: {node: '>=20.0.0'}`. This package still advertises `node: '>=18'` and `peerDependencies.next: '>=9'`. Transitive `yaml@2.0.0-1` is a pre-release YAML parser (swagger-jsdoc pin). Issue #1149 (outdated `glob`) is improved in 6.3.0 (`glob@11.1.0`), but swagger-jsdoc still owns globbing `.next` when `scanBuildOutput` is on.
+- Impact: Node 18 installs may warn or break on swagger-jsdoc 6.3; YAML JSDoc edge cases depend on an old `yaml` prerelease. Next 9–12 are claimed but untested (devDependency is Next `16.3.3`).
+- Migration plan: Bump `engines` to `>=20` (Next 16 examples already need `>=20.9`), or pin a swagger-jsdoc that supports 18. Document that Pages Next 9 is historical only.
+
+**`isarray@2.0.5`:**
+- Risk: Unused direct dependency (see Tech Debt).
+- Impact: Audit noise only.
+- Migration plan: Remove.
+
+**Example `swagger-ui-react` (not a library dependency):**
+- Risk: Examples depend on `swagger-ui-react` (`latest` in next13-simple; `^5.20.8` in 14/15/16). It still uses `UNSAFE_componentWillReceiveProps` on `ExamplesSelect` / `ParameterRow` (README, issue #1231, AGENTS.md). Webpack needs `transpilePackages: ['react-syntax-highlighter', 'swagger-client', 'swagger-ui-react']` (swagger-ui issue #8245). `#apg-lite` resolution failures (issue #1032) were closed as not planned.
+- Impact: Strict Mode warnings and occasional bundler failures in *consumer* apps that copy the example. This package does not depend on swagger-ui-react.
+- Migration plan: Keep examples on `next/dynamic(..., { ssr: false })`; point README at Scalar / Stoplight (next13 `pages/playground.tsx` already uses Elements). Never pin `latest`.
+
+**`cleye@1.3.4`:**
+- Risk: Small CLI parser, last-line 1.x. CLI itself is untested (see Test Coverage).
+- Impact: Flag/argv regressions ship unnoticed.
+- Migration plan: Add a CLI test (spawn `dist/cli.js`) before changing parsers.
+
+**`@types/swagger-jsdoc` in `dependencies`:**
+- Risk: Type-only package on the runtime graph. Fine for TS consumers, unusual for a dual CJS/ESM build.
+- Impact: Extra install; types can drift from swagger-jsdoc if not bumped together (Renovate `group:allNonMajor` + `automerge: true` in `renovate.json`).
+- Migration plan: Keep inlined if the public `SwaggerOptions` extends `Options`; otherwise move to `devDependencies` and bundle types.
+
+## Missing Critical Features
+
+**No App Router spec Route Handler:**
+- Problem: `withSwagger` is Pages-only (`NextApiResponse`). Issue #1190. App examples embed the spec in a Server Component instead of serving JSON.
+- Blocks: Drop-in `/api/doc` JSON in App Router without writing a custom `route.ts`.
+
+**autoDoc is path + method only:**
+- Problem: Generated operations are `{ summary, parameters: path-params, responses: { 200 } }`. No requestBody, query/header params, status codes from `Response.json`, or tags. Catch-alls are a single string `{slug}`. Private `_` folders are not excluded. Pages Router files are not auto-documented.
+- Blocks: Accurate docs without manual `@swagger` JSDoc for every interesting endpoint.
+
+**No schema inference / OpenAPI 3.1 first-class support:**
+- Problem: Models must be JSDoc or `*.swagger.yaml` (next13 `typeconv` flow). `definition.openapi` is passed through to swagger-jsdoc; nothing validates 3.1 vs 3.0.
+- Blocks: TypeScript-first schema generation inside this library.
+
+**CLI is a thin JSON wrapper:**
+- Problem: No `--apiFolder` override, no YAML output, no watch mode, no config schema, no `mkdir`. `outputFile` on `SwaggerOptions` and `--output` can diverge.
+- Blocks: Usable `postbuild` codegen without extra shell.
+
+**Edge / non-Node runtimes:**
+- Problem: `node:fs` + `initSync()` WASM. Cannot run in Edge middleware or the Edge route runtime.
+- Blocks: Generating the spec on the Edge; callers must use Node runtime or a prebuilt `specFile`.
+
+## Test Coverage Gaps
+
+**CLI (`src/cli.ts`) is untested:**
+- What's not tested: Missing config, invalid JSON, default `--output`, nested output without `public/`, double-write when config has `outputFile`.
+- Files: `src/cli.ts`, `test/index.test.ts`
+- Risk: The documented standalone path (`npx next-swagger-doc-cli … --output public/swagger.json`) can fail on a clean tree (no `mkdir`).
+- Priority: High
+
+**`withSwagger` handler is untested:**
+- What's not tested: Status 200 body, 400 error path, option plumbing (`specFile`, `scanBuildOutput`, `autoDoc`). The suite named `describe('withSwagger')` only snapshots `createSwaggerSpec`.
+- Files: `src/swagger.ts`, `test/index.test.ts`, `test/__snapshots__/index.test.ts.snap`
+- Risk: Error-status / leak regressions ship without failing CI.
+- Priority: High
+
+**Production-build + autoDoc interaction is untested:**
+- What's not tested: `extractApiInfo` while `NEXT_PHASE=phase-production-build` and `.next/server/...` exists; union of source methods with stale compiled methods; `scanBuildOutput: true` actually globbing via `createSwaggerSpec` (unit tests only call `shouldScanBuildDirectory`).
+- Files: `src/auto-doc.ts`, `src/swagger.ts`, `test/index.test.ts`, `test/fixtures/.next/server/app/api/compiled/route.js`
+- Risk: Reintroduces Vercel ENOENT (#1157) or extra phantom operations.
+- Priority: High
+
+**Compiled output is not a real Next artifact:**
+- What's not tested: webpack/turbopack `route.js` (CJS / runtime exports); parse failures in `getExportedMethods` (the `console.warn` branch); `loadSpecFile` invalid JSON; `__NEXT_ROUTER_BASEPATH` server injection; `schemaFolders`; `public/**/*.json` merge; `phase-export`.
+- Files: `src/route-parser.ts`, `src/swagger.ts`, `test/fixtures/.next/`
+- Risk: Standalone autoDoc fallback documented in README may no-op on real builds (issue #1228 class of problem).
+- Priority: High
+
+**Route conventions with no fixtures:**
+- What's not tested: Private `_` folders, intercepting `(.)` routes, `.yml` schemas, Pages Router autoDoc (expected empty), `src/pages/api`, custom `distDir`.
+- Files: `src/route-path.ts`, `src/auto-doc.ts`, `test/fixtures/app/`
+- Risk: Next.js private folders leak into the spec; new folder conventions silently mis-parse.
+- Priority: Medium
+
+**No coverage gates:**
+- What's not tested: `vitest.config.ts` is `{ test: { globals: true } }` only — no `coverage.thresholds`. `pnpm coverage` can pass with untested CLI/handler.
+- Files: `vitest.config.ts`, `package.json`
+- Risk: New files can land at 0% coverage.
+- Priority: Low
+
+---
+
+*Concerns audit: 2026-08-26*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -29,7 +29,7 @@
 - Fix approach: Replace the security template with a reporting contact and actual supported versions; backfill changelog from GitHub releases.
 
 **Idle tooling and config drift:**
-- Issue: DevDependencies `c8`, `size-limit`, and `@skypack/package-check` have no scripts. `biome.json` `$schema` is `1.7.0` while Biome is `1.9.4`, and `linter.rules.recommended` is `false`. `tsconfig.json` `include`s `"types"` but no `types/` directory exists; `moduleResolution` is legacy `"node"` despite `"type": "module"`. Example `packageManager` is `pnpm@10.8.0` vs root `pnpm@10.34.5`. Tests under `describe('withSwagger')` call `createSwaggerSpec`, not `withSwagger`. CLI comment says `._.filePath` but the parameter is `configFile`.
+- Issue: DevDependencies `c8`, `size-limit`, and `@skypack/package-check` have no scripts. `biome.json` and the installed Biome are 2.5.10, but `.pre-commit-config.yaml` still installs Biome 1.7.0. `tsconfig.json` `include`s `"types"` but no `types/` directory exists; `moduleResolution` is legacy `"node"` despite `"type": "module"`. Example `packageManager` is `pnpm@10.8.0` vs root `pnpm@11.24.0`; `AGENTS.md` also still documents pnpm 10.34.5. Tests under `describe('withSwagger')` call `createSwaggerSpec`, not `withSwagger`. CLI comment says `._.filePath` but the parameter is `configFile`.
 - Files: `package.json`, `biome.json`, `tsconfig.json`, `test/index.test.ts`, `src/cli.ts`, `examples/*/package.json`
 - Impact: Dead tooling in every install; weaker lint than Biome recommended; contributors copy the wrong test name when extending the handler API.
 - Fix approach: Drop unused devDeps, align Biome schema, fix tsconfig `include`, rename the snapshot describe block, fix the CLI comment.
@@ -176,8 +176,8 @@ This library is a build/runtime doc generator, not an auth system. No credential
 - Impact: Strict Mode warnings and occasional bundler failures in *consumer* apps that copy the example. This package does not depend on swagger-ui-react.
 - Migration plan: Keep examples on `next/dynamic(..., { ssr: false })`; point README at Scalar / Stoplight (next13 `pages/playground.tsx` already uses Elements). Never pin `latest`.
 
-**`cleye@1.3.4`:**
-- Risk: Small CLI parser, last-line 1.x. CLI itself is untested (see Test Coverage).
+**`cleye@2.6.0`:**
+- Risk: Small CLI parser. CLI itself is untested (see Test Coverage).
 - Impact: Flag/argv regressions ship unnoticed.
 - Migration plan: Add a CLI test (spawn `dist/cli.js`) before changing parsers.
 

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -32,9 +32,9 @@
 ## Code Style
 
 **Formatting:**
-- Tool: Biome (`@biomejs/biome` 1.9.4), invoked as `pnpm format` → `biome format src` in `package.json`.
+- Tool: Biome (`@biomejs/biome` 2.5.10), invoked as `pnpm format` → `biome format src` in `package.json`.
 - Settings from `biome.json`: 2-space indent, LF line endings, 80-column `lineWidth`, single quotes (`quoteStyle: "single"`), always semicolons, ES5 trailing commas, `arrowParentheses: "always"`, `bracketSpacing: true`.
-- `organizeImports.enabled: true` in `biome.json`; format/lint scripts scope to `src/` only (tests are not formatted by the package scripts).
+- Import organization is enabled through `assist.actions.source.organizeImports` in `biome.json`; format/lint scripts scope to `src/` only (tests are not formatted by the package scripts).
 - TypeScript in `tsconfig.json`: `"strict": true`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`, `forceConsistentCasingInFileNames`, ESM (`"type": "module"` in `package.json`, `"module": "esnext"`).
 
 **Linting:**

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,65 +1,124 @@
-# CONVENTIONS — next-swagger-doc
+# Coding Conventions
 
-## Code Style (enforced by Biome — `biome.json`)
+**Analysis Date:** 2026-08-26
 
-- **Indentation**: 2 spaces, LF line endings
-- **Quotes**: single quotes; double quotes for JSX
-- **Semicolons**: always
-- **Trailing commas**: es5 (objects/arrays, not function params)
-- **Line width**: 80
-- **Imports**: auto-organized (`organizeImports` enabled); type-only imports preferred (`useImportType`, `useExportType`)
-- **Arrow functions** preferred over function expressions (`useArrowFunction`); block statements required (`useBlockStatements`)
+## Naming Patterns
 
-## Lint Rules (curated, `recommended: false`)
+**Files:**
+- Library modules in `src/` use kebab-case TypeScript files: `src/auto-doc.ts`, `src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`, `src/swagger.ts`, `src/cli.ts`, `src/index.ts`.
+- Tests live as a single file `test/index.test.ts` with snapshots at `test/__snapshots__/index.test.ts.snap`.
+- Fixtures mirror Next.js App Router filenames (`route.ts`, compiled `route.js`) under `test/fixtures/`.
+- No default-export React-style `index.ts` barrels except the public package entry `src/index.ts`.
 
-Biome is configured with explicit rule sets rather than the recommended preset:
+**Functions:**
+- camelCase verb phrases: `createSwaggerSpec`, `extractApiInfo`, `generateAutoDoc`, `getExportedMethods`, `routeToOpenApiPaths`, `discoverSpecLocations`, `mergeAutoDoc`, `loadSpecFile` in `src/swagger.ts` / `src/auto-doc.ts` / `src/route-parser.ts` / `src/route-path.ts` / `src/spec-source.ts` / `src/merge-auto-doc.ts`.
+- Boolean predicates use `is*` / `should*`: `isAutoDocEnabled`, `shouldScanBuildDirectory`, `isRouteFile` in `src/swagger.ts` and `src/auto-doc.ts`.
+- Unexported helpers stay camelCase and file-private: `resolveUserPath` (`src/swagger.ts`), `getRouteFiles` / `getPathParameters` (`src/auto-doc.ts`), `getApiSegments` (`src/route-path.ts`).
+- HTTP handler names in fixtures and App Router code are uppercase Next.js exports (`GET`, `HEAD`, `PATCH`, `DELETE`, `OPTIONS`) as in `test/fixtures/app/api/health/route.ts`.
 
-- **complexity**: no useless catch/constructor/ternary/type-constraint; `useOptionalChain`, `useRegexLiterals`, `useLiteralKeys`
-- **correctness**: no unused variables, no undeclared variables, `useIsNan`, no unsafe optional chaining
-- **security**: `noGlobalEval`
-- **style**: `noVar`, `useConst`, `useNamingConvention` (warn), `useAsConstAssertion`, `useExponentiationOperator`, restricted globals (`event`, `atob`, `btoa`)
-- **suspicious**: `noDebugger`, `noDoubleEquals`, `noPrototypeBuiltins`, `noRedeclare`, `useValidTypeof`, etc.
-- `dist/` and `.eslintrc.cjs`/`vite.config.ts` are ignored; `.d.ts` files relax `noUnusedVariables`
+**Variables:**
+- camelCase locals: `sourceDirectory`, `buildDirectory`, `scanFolders`, `apiInfos`, `exportSpecifiers` in `src/swagger.ts`, `src/auto-doc.ts`, `src/route-parser.ts`.
+- Module constants are `SCREAMING_SNAKE_CASE`: `HTTP_METHODS` in `src/route-parser.ts`, `NEXT_BUILD_PHASES` in `src/swagger.ts`.
+- `const` everywhere (Biome `useConst` / `noVar` in `biome.json`); no `var`.
+- Option fields on `SwaggerOptions` in `src/swagger.ts` match user-facing camelCase API names: `apiFolder`, `schemaFolders`, `outputFile`, `specFile`, `autoDoc`, `scanBuildOutput`.
 
-## TypeScript Conventions
+**Types:**
+- PascalCase `export type` aliases, never `interface`: `SwaggerOptions`, `AutoDocOptions` in `src/swagger.ts`; `ApiInfo` in `src/auto-doc.ts`; `SpecLocations` in `src/spec-source.ts`; `PathsObject` in `src/merge-auto-doc.ts`.
+- Object types use inline `{ field: Type }` shapes, often with optional `?` fields.
+- External OpenAPI types are imported (`OAS3Definition`, `Options` from `swagger-jsdoc` in `src/swagger.ts`) rather than re-declared.
+- String unions / const arrays with `as const` for closed sets (`HTTP_METHODS` in `src/route-parser.ts`).
+- No `any` in `src/` (AGENTS.md + TypeScript `strict` in `tsconfig.json`). CLI JSON parse uses a double assertion `as unknown as SwaggerOptions` in `src/cli.ts`.
 
-- **Strict mode** (`strict: true`) plus `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`
-- `moduleResolution: node`, `esModuleInterop`, `skipLibCheck`, `forceConsistentCasingInFileNames`
-- `importHelpers: true` (tslib)
-- Type-only imports via `import type { … }` (e.g. `import type { NextApiRequest, NextApiResponse } from 'next'`)
-- `as const` for literal tuples (`HTTP_METHODS`)
-- No default exports in library code; named exports only
+## Code Style
 
-## Naming
+**Formatting:**
+- Tool: Biome (`@biomejs/biome` 1.9.4), invoked as `pnpm format` → `biome format src` in `package.json`.
+- Settings from `biome.json`: 2-space indent, LF line endings, 80-column `lineWidth`, single quotes (`quoteStyle: "single"`), always semicolons, ES5 trailing commas, `arrowParentheses: "always"`, `bracketSpacing: true`.
+- `organizeImports.enabled: true` in `biome.json`; format/lint scripts scope to `src/` only (tests are not formatted by the package scripts).
+- TypeScript in `tsconfig.json`: `"strict": true`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`, `forceConsistentCasingInFileNames`, ESM (`"type": "module"` in `package.json`, `"module": "esnext"`).
 
-- Functions: `camelCase`, action-first (`createSwaggerSpec`, `extractApiInfo`, `getRouteFiles`)
-- Types: `PascalCase` (`SwaggerOptions`, `ApiInfo`, `AutoDocOptions`)
-- Constants: `UPPER_SNAKE_CASE` (`HTTP_METHODS`, `defaultOptions`)
-- Private helpers are module-local (not exported)
+**Linting:**
+- Tool: Biome linter via `pnpm lint` → `biome lint src` in `package.json`.
+- `linter.rules.recommended` is `false` in `biome.json`; correctness/complexity/style/suspicious rules are enabled individually as `"error"`.
+- Notable style rules in `biome.json`: `useImportType` / `useExportType`, `useArrowFunction`, `useOptionalChain`, `noUselessElse`, `noNegationElse`, `useBlockStatements`, `useConst` / `noVar`, `noDoubleEquals`, `useConsistentArrayType` (shorthand `T[]`), `noRestrictedGlobals` (`event`, `atob`, `btoa`).
+- `useNamingConvention` is `"warn"` with `strictCase: false`.
+- Linter ignore: `dist`, `.eslintrc.cjs`, `vite.config.ts` in `biome.json`.
+- Conventional commits (`feat`, `fix`, `chore`, `docs`, `test`) per `AGENTS.md`; release script in `package.json` uses `chore: release v%s`.
 
-## Patterns
+## Import Organization
 
-- **Default parameters** for options (`apiFolder = 'pages/api'`, `autoDoc = false`)
-- **Destructuring** options in function signatures, spreading the rest into swagger-jsdoc options
-- **Functional style**: `flatMap`, `filter`, `map`, `Object.fromEntries`; `Set`/`Map` for dedup (`apiInfos` map, `methods` set)
-- **JSDoc comments** on public API functions (`createSwaggerSpec`, `withSwagger`) describing params and returns
-- **No TODO/FIXME/HACK comments** anywhere in the codebase (verified via search)
+**Order:**
+1. Node builtins, preferring the `node:` protocol (`node:fs`, `node:path` in `src/swagger.ts`, `src/auto-doc.ts`, `src/spec-source.ts`). Exception: `src/cli.ts` still imports `from 'fs'`.
+2. External packages, with type-only imports via `import type` or inline `type` specifiers (`next`, `swagger-jsdoc`, `cleye`, `es-module-lexer` in `src/swagger.ts`, `src/cli.ts`, `src/route-parser.ts`).
+3. Relative local modules last (`./auto-doc`, `./merge-auto-doc`, `./spec-source` in `src/swagger.ts`; `./route-parser`, `./route-path`, `./spec-source` in `src/auto-doc.ts`).
+- Blank lines between groups appear in `src/auto-doc.ts` and `src/cli.ts`; `src/swagger.ts` keeps groups consecutive. Named imports are alphabetized within a specifier when Biome organizes them (e.g. `dirname, isAbsolute, join` in `src/swagger.ts`).
+
+**Path Aliases:**
+- None in the library. `tsconfig.json` has no `paths` / `baseUrl`; all library imports are relative (`./swagger`, `../src`).
+- Example apps under `examples/` use `@/` (e.g. `@/types/nav`) — do not copy that into `src/`.
 
 ## Error Handling
 
-- `withSwagger` wraps spec creation in try/catch: success → `res.status(200).send(spec)`; failure → `res.status(400).json({ error })` with a fallback message `'Failed to create Swagger spec'`
-- Error message extraction uses `error instanceof Error ? error.message : fallback`
-- No custom error classes; logging is limited to a `console.warn` in `route-parser.ts` when a route file fails to parse
+**Patterns:**
+- Fail soft for parse/scan problems: `getExportedMethods` in `src/route-parser.ts` wraps `parse()` in `try/catch`, logs a warning, and returns `[]` so a bad route file is skipped.
+- Missing files return `undefined` or empty data rather than throwing: `loadSpecFile` in `src/swagger.ts` returns `undefined` when the path does not exist; `extractApiInfo` in `src/auto-doc.ts` filters to existing dirs and can yield `[]`.
+- HTTP wrapper `withSwagger` in `src/swagger.ts` catches errors and responds `400` with `{ error: message }`, using `error instanceof Error ? error.message : 'Failed to create Swagger spec'`.
+- Boolean option guards short-circuit (`isAutoDocEnabled`, `shouldScanBuildDirectory` in `src/swagger.ts`) instead of throwing on invalid combinations.
+- CLI in `src/cli.ts` does not catch `JSON.parse` / write failures; those surface as process crashes.
+- Tests that touch the filesystem use `try/finally` with `rmSync` in `test/index.test.ts` rather than throwing assertions.
 
-## Module & File Conventions
+## Logging
 
-- ESM (`"type": "module"`), Node built-ins imported explicitly (`node:fs`, `node:path`)
-- Single responsibility per file (swagger = API, auto-doc = scanner, route-parser = parser, cli = CLI)
-- `src/index.ts` is a pure barrel re-export
+**Framework:** `console`
 
-## Commit / Release Conventions
+**Patterns:**
+- CLI progress: `console.log` in `src/cli.ts` prints the output path and raw config before `writeFileSync`.
+- Recoverable parse failures: `console.warn` in `src/route-parser.ts` prefixes messages with `next-swagger-doc:` and includes the optional `sourceName` plus the caught error.
+- No debug/info logger, no structured logging library. Library hot paths (`createSwaggerSpec` in `src/swagger.ts`) are silent on success.
 
-- Conventional-ish commit messages (`feat:`, `chore:`, `fix:`)
-- Changelog via Changie fragments in `.changes/unreleased/`
-- Renovate auto-merges non-major dependency updates
-- Pre-commit hooks: Prettier (html/css/markdown) + Biome check
+## Comments
+
+**When to Comment:**
+- Explain *why* a constraint exists, not restated control flow. Example: `NEXT_BUILD_PHASES` and `shouldScanBuildDirectory` JSDoc in `src/swagger.ts` document the Vercel `export-detail.json` ENOENT failure.
+- One-line notes for non-obvious setup: `// es-module-lexer needs its WASM engine ready before parse() can run.` in `src/route-parser.ts`; `// Append base path server element to server array` in `src/swagger.ts`.
+- File-level ownership comments when a module is the single source of a convention (`src/route-path.ts` owns Next.js folder segment translation; `src/spec-source.ts` owns `.next/server/<folder>` layout).
+- Do not comment obvious maps/filters.
+
+**JSDoc/TSDoc:**
+- Public functions get a short block describing behavior and return value: `createSwaggerSpec`, `withSwagger`, `loadSpecFile`, `isAutoDocEnabled`, `shouldScanBuildDirectory` in `src/swagger.ts`; `extractApiInfo` in `src/auto-doc.ts`; `getExportedMethods` in `src/route-parser.ts`; `mergeAutoDoc` in `src/merge-auto-doc.ts`.
+- Option fields on `SwaggerOptions` in `src/swagger.ts` use field-level `/** ... */` (including multi-line notes for `specFile`, `scanBuildOutput`).
+- Older `createSwaggerSpec` / `withSwagger` blocks still use `@param options.*` tags that predate the current destructured signature — new APIs prefer a prose summary over `@param` lists.
+- No module-level `@packageDocumentation`. Types themselves are rarely JSDoc'd unless they wrap user options.
+
+## Function Design
+
+**Size:** Keep units small and single-purpose. Helpers such as `resolveUserPath` (`src/swagger.ts`), `isRouteFile` / `getPathParameters` (`src/auto-doc.ts`), and `getApiSegments` (`src/route-path.ts`) are ~5–20 lines. Feature functions (`extractApiInfo`, `routeToOpenApiPaths`, `mergeAutoDoc`, `getExportedMethods`) stay under ~40 lines. The largest composer is `createSwaggerSpec` in `src/swagger.ts` (~80 lines): scan, swagger-jsdoc, auto-doc merge, optional write.
+
+**Parameters:**
+- Multi-field APIs take a destructured options object, often with an inline type and defaults: `shouldScanBuildDirectory({ sourceDirectory, buildDirectory, scanBuildOutput, nextPhase = process.env.NEXT_PHASE })` in `src/swagger.ts`; `createSwaggerSpec({ apiFolder = 'pages/api', ... })`.
+- Inject `cwd = process.cwd()` as a last/default argument so tests can point at fixtures (`extractApiInfo`, `discoverSpecLocations`, `loadSpecFile` in `src/auto-doc.ts`, `src/spec-source.ts`, `src/swagger.ts`).
+- Rest-spread remaining swagger-jsdoc options (`...swaggerOptions` in `src/swagger.ts`).
+- Default-parameter-last (Biome `useDefaultParameterLast`).
+
+**Return Values:**
+- Predicates and loaders annotate returns: `boolean`, `OAS3Definition | undefined`, `ApiInfo[]`, `string[]`, `SpecLocations` (`src/swagger.ts`, `src/auto-doc.ts`, `src/spec-source.ts`).
+- Composers may rely on inference (`createSwaggerSpec`, `generateAutoDoc`, `mergeAutoDoc`, `withSwagger`).
+- Missing optional data → `undefined`; no matches → `[]`; HTTP middleware returns a nested `(req, res) => void` closure from `withSwagger` in `src/swagger.ts`.
+- Avoid throwing for expected empty states.
+
+## Module Design
+
+**Exports:** Named exports only in `src/` — no `export default`. Public surface is functions + option types. Constants that are part of the algorithm (`HTTP_METHODS` in `src/route-parser.ts`) are exported for reuse inside the package. CLI in `src/cli.ts` is a bin script (`next-swagger-doc-cli` in `package.json`), not a library export.
+
+**Barrel Files:** `src/index.ts` re-exports only the public API:
+
+```ts
+export * from './auto-doc';
+export * from './swagger';
+```
+
+Internal modules (`src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`) are imported by path, including from tests. Do not add them to the barrel unless they are intended for consumers. `dist/` is generated by pkgroll from `src/` — never edit `dist/` (`AGENTS.md`).
+
+---
+
+*Convention analysis: 2026-08-26*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,46 +1,124 @@
-# INTEGRATIONS — next-swagger-doc
+# External Integrations
 
-This is a **library**, not a service-backed app. It has no database, no auth provider, no external API calls, and no webhooks at runtime. Integrations are limited to the libraries it builds on and the tooling around the repo.
+**Analysis Date:** 2026-08-26
 
-## Core Library Integrations
+## APIs & External Services
 
-| Integration | Type | How it's used |
-| --- | --- | --- |
-| **swagger-jsdoc** (`src/swagger.ts`) | npm library | Parses `@swagger` JSDoc annotations from route files and merges them with the OpenAPI `definition` into a spec object. This is the entire "engine" of the library. |
-| **Next.js** (`src/swagger.ts`) | peer framework | `NextApiRequest`/`NextApiResponse` types for `withSwagger` middleware; scans `.next/server` build output; reads `__NEXT_ROUTER_BASEPATH` env for base-path-aware servers. |
-| **cleye** (`src/cli.ts`) | npm library | CLI flag/parameter parsing for the `next-swagger-doc-cli` binary. |
-| **es-module-lexer** (`src/route-parser.ts`) | npm library | Real ESM lexer that extracts exported names from route source, replacing the hand-rolled string scanner in auto-doc. |
+**None in the library runtime.** `next-swagger-doc` is an OpenAPI generator: it reads local Next.js route files and writes a spec. There are no `fetch` / HTTP client calls in `src/` (confirmed across `src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`, `src/route-parser.ts`, `src/spec-source.ts`, `src/merge-auto-doc.ts`, `src/route-path.ts`).
 
-## Build / Docs / Quality Tooling
+**OpenAPI / Swagger (local library, not a hosted API):**
+- swagger-jsdoc 6.3.0 - parse `@swagger` JSDoc into OAS3 (`package.json`, `src/swagger.ts` `createSwaggerSpec`).
+- SDK/Client: `swagger-jsdoc` (`src/swagger.ts`).
+- Auth: none.
 
-| Integration | Purpose |
-| --- | --- |
-| **pkgroll** | Bundling to dual ESM/CJS output |
-| **typedoc** | Generates API reference docs (used in `vercel-build`) |
-| **Biome** | Lint + format |
-| **Vitest** | Unit testing |
-| **Renovate** (`renovate.json`) | Automated dependency PRs; auto-merges non-major bumps |
-| **pre-commit** (`.pre-commit-config.yaml`) | Prettier + Biome hooks |
-| **Changie** (`.changie.yaml`, `.changes/`) | Changelog fragment management |
-| **cspell** | Spell checking |
-| **all-contributors-cli** | Contributor badge/table in README |
+**OpenAPI UI viewers (examples only, in-process):**
+- swagger-ui-react - render spec in demo apps (`examples/next14-app/app/api-doc/react-swagger.tsx`, `examples/next13-simple/pages/api-doc.tsx`, `examples/next13-simple/pages/swagger.tsx`). Not a library dependency (`README.md`, `AGENTS.md`).
+- @stoplight/elements 9.0.1 - alternate viewer (`examples/next13-simple/pages/playground.tsx` loads `/swagger.json`).
+- Scalar is mentioned as a consumer option only (`README.md`, `AGENTS.md`); no Scalar package in this repo.
 
-## CI / SaaS
+**Package registry / docs hosting (publish-time, not runtime):**
+- npm registry - package `next-swagger-doc` (`package.json` name/version, `README.md` npm badges).
+- SDK/Client: npm publish of `dist/` (`package.json` `files`, `exports`).
+- Auth: npm token not present in repo (no `.npmrc` publish config).
+- TypeDoc docs at `https://next-swagger-doc.productsway.com/` via `package.json` `vercel-build`.
+- Demo app at `https://next-swagger-doc-demo.productsway.com/api-doc` (`README.md`).
+- GitHub repo `https://github.com/jellydn/next-swagger-doc` (`package.json` `repository`).
 
-| Integration | Location | Purpose |
-| --- | --- | --- |
-| **GitHub Actions — CodeQL** | `.github/workflows/codeql-analysis.yml` | Security scanning (JavaScript), on push/PR to `main` + weekly schedule |
-| **GitHub Actions — CodeSee** | `.github/workflows/codesee-arch-diagram.yml` | Architecture diagram (uses `CODESEE_ARCH_DIAG_API_TOKEN` secret) |
-| **GitHub Sponsors / Ko-fi** | `.github/FUNDING.yml` | Funding links |
+**Example-only placeholder OAuth URLs (not wired):**
+- `https://example.com/oauth/authorize` and `https://example.com/oauth/token` appear as OpenAPI `securitySchemes.OAuth2` documentation samples (`examples/next14-app/lib/swagger.ts`, `examples/next15-app/lib/swagger.ts`, `examples/next16-app/lib/swagger.ts`, `test/index.test.ts`). No OAuth client, no token exchange.
 
-> Note: there is **no** CI workflow for running tests or lint — those run only locally/pre-commit.
+**Dependency / architecture services (CI, not app):**
+- Renovate - dependency PRs (`renovate.json`).
+- SDK/Client: Renovate GitHub app (config only).
+- Auth: none in repo.
+- CodeSee - architecture diagrams (`.github/workflows/codesee-arch-diagram.yml`).
+- SDK/Client: `Codesee-io/codesee-action@v2`.
+- Auth: `secrets.CODESEE_ARCH_DIAG_API_TOKEN`.
 
-## Example App Integrations (not part of the library)
+## Data Storage
 
-- `swagger-ui-react` — renders the generated spec as Swagger UI in `examples/next14-app` and `examples/next15-app`
-- `next-themes`, `tailwindcss`, `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`, `@radix-ui/react-slot`, `sharp` — UI stack of the example apps
-- `openapi-types` — OpenAPI type helpers in examples
+**Databases:**
+- None. No Prisma, SQL, Redis, Mongo, or other DB client in `package.json` or `src/`. Example API handlers return in-memory JSON/text (`examples/next13-simple/pages/api/hello.ts`, `examples/next14-app/app/api/hello/route.ts`). Evidence: `AGENTS.md` “No extra services need to be started.”
 
-## Auth / Security Schemes (documented, not connected)
+**File Storage:**
+- Local filesystem only. Reads API/schema files and optional prebuilt spec; writes JSON spec.
+  - Source scan: `apiFolder` (default `pages/api`) + `schemaFolders` + `public/**/*.swagger.yaml|json` (`src/swagger.ts`, `src/spec-source.ts`).
+  - Compiled fallback: `.next/server/<folder>` when source is missing and Next.js is not compiling (`src/spec-source.ts`, `src/swagger.ts` `shouldScanBuildDirectory`).
+  - Prebuilt load: `specFile` e.g. `public/swagger.json` (`src/swagger.ts` `loadSpecFile`, `examples/next14-app/lib/swagger.ts`).
+  - Write: `outputFile` (`src/swagger.ts`) and CLI `--output` default `public/swagger.json` (`src/cli.ts`).
+  - Example static spec: `examples/next13-simple/public/swagger.json`; YAML schemas under `examples/next13-simple/models/openapi/`.
+- Connection: none (paths relative to `process.cwd()` in `src/swagger.ts` `resolveUserPath`).
+- Client: Node `fs` (`src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`).
 
-The library and examples document OpenAPI security schemes (Bearer JWT, OAuth2) in the generated spec — these are **documentation only**; no authentication is enforced or integrated.
+**Caching:**
+- None. Spec is generated per `createSwaggerSpec` / `withSwagger` call (`src/swagger.ts`). No Redis, CDN cache config, or in-memory cache layer. `specFile` is a static file load, not a cache.
+
+## Authentication & Identity
+
+**Auth Provider:**
+- None implemented. Library does not authenticate users or call IdPs.
+
+**Implementation:**
+- OpenAPI documentation of consumer APIs only. Default spec has no security (`src/swagger.ts` `defaultOptions`). Tests and examples document optional schemes:
+  - HTTP Bearer JWT (`test/index.test.ts` `bearerAuth`; `examples/next14-app/lib/swagger.ts` `BearerAuth`).
+  - OAuth2 authorization code with example.com placeholder URLs (`test/index.test.ts`, `examples/next14-app/lib/swagger.ts`).
+- `security: []` in example `getApiDocs` (`examples/next14-app/lib/swagger.ts`) — schemes declared, not required.
+- No NextAuth, Clerk, Auth0, sessions, or cookies in this repo.
+- `SECURITY.md` is the GitHub template stub (version table does not match package 0.5.0 in `package.json`); no reporting endpoint or bounty program is specified.
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None (no Sentry, Datadog, Bugsnag, or similar in `package.json` or workflows).
+- GitHub CodeQL static analysis on JavaScript (`.github/workflows/codeql-analysis.yml`, `github/codeql-action` v3.37.8) — security scanning, not production error tracking.
+- CodeSee architecture diagrams (`.github/workflows/codesee-arch-diagram.yml`) — repo visualization, `continue-on-error: true`.
+
+**Logs:**
+- `console.warn` when `es-module-lexer` cannot parse a route file (`src/route-parser.ts`).
+- `console.log` for CLI generation (`src/cli.ts`).
+- `withSwagger` maps thrown errors to HTTP 400 JSON `{ error }` (`src/swagger.ts`); success is HTTP 200 with the spec.
+- Example Next.js 13 config strips `console` in production (`examples/next13-simple/next.config.js` `compiler.removeConsole: true`).
+- No structured logger, log drain, or APM.
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Library: npm (`package.json`, `README.md`). Not a hosted SaaS.
+- API docs: TypeDoc built as `vercel-build` (`package.json`) for `https://next-swagger-doc.productsway.com/` (`README.md`, `examples/next14-app/config/site.ts` `links.docs`).
+- Demo Next.js app: `https://next-swagger-doc-demo.productsway.com/api-doc` (`README.md`). Vercel is the documented example deploy path (`examples/next13-simple/README.md`) and a first-class build constraint (`src/swagger.ts` comments on Vercel `export-detail.json` ENOENT; `README.md` “Vercel builds”).
+- No `vercel.json` / Dockerfile / k8s manifests in the repo.
+
+**CI Pipeline:**
+- GitHub Actions only two workflows — no test, lint, or npm-publish workflow under `.github/workflows/`:
+  - CodeQL on push/PR to `main` + weekly cron (`18 18 * * 5`) (`.github/workflows/codeql-analysis.yml`).
+  - CodeSee on push to `main` and `pull_request_target` (`.github/workflows/codesee-arch-diagram.yml`).
+- Renovate automerges non-major updates (`renovate.json`).
+- Release script `pnpm release:version` uses bumpp to commit/tag/push (`package.json`); changelog via Changie (`CHANGELOG.md`).
+- Local quality: Vitest (`package.json` `test`), Biome (`package.json` `lint`/`format`), pre-commit (`.pre-commit-config.yaml`).
+- Funding metadata only: GitHub Sponsors `jellydn`, Ko-fi `dunghd` (`.github/FUNDING.yml`); PayPal / Buy Me a Coffee links in `README.md` — not integrations.
+
+## Environment Configuration
+
+**Required env vars:**
+- None required to generate a spec or run tests. Library options come from `SwaggerOptions` / `next-swagger-doc.json` (`src/swagger.ts`, `src/cli.ts`, `examples/next13-simple/next-swagger-doc.json`).
+- Optional / injected (not user secrets):
+  - `NEXT_PHASE` — Next.js build phase; when set to `phase-production-build`, `phase-production-compile`, or `phase-export`, compiled `.next` is not globbed (`src/swagger.ts` `shouldScanBuildDirectory`).
+  - `__NEXT_ROUTER_BASEPATH` — if set and `definition.servers` is absent, becomes OpenAPI `servers[0].url` (`src/swagger.ts`).
+  - `NODE_ENV` — example Tailwind indicator hidden in production (`examples/next14-app/components/tailwind-indicator.tsx` and next15/next16 copies).
+- No `.env`, `.env.example`, or `process.env` API keys in source.
+
+**Secrets location:**
+- GitHub Actions secret `CODESEE_ARCH_DIAG_API_TOKEN` (`.github/workflows/codesee-arch-diagram.yml`).
+- No Vault, AWS Secrets Manager, Doppler, or committed credentials. `SECURITY.md` does not define a secret-handling process.
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None. Library HTTP surface is optional `withSwagger` Pages Router handler that **returns** the spec (`src/swagger.ts`); example routes are hello-world GET handlers (`examples/next13-simple/pages/api/hello.ts`, `examples/next14-app/app/api/hello/route.ts`, `examples/next13-simple/pages/api/doc.ts`). No `/webhooks` paths, no signature verification.
+
+**Outgoing:**
+- None. No outbound HTTP, no Slack/GitHub webhook posts, no OAuth token callbacks (example.com URLs in `examples/next14-app/lib/swagger.ts` are spec text only). CLI writes a local file (`src/cli.ts`).
+
+---
+
+*Integration audit: 2026-08-26*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,77 +1,115 @@
-# STACK — next-swagger-doc
+# Technology Stack
 
-> Library that generates Swagger/OpenAPI JSON from Next.js API routes. Published on npm as `next-swagger-doc`, MIT licensed, maintained by Huynh Duc Dung (jellydn).
+**Analysis Date:** 2026-08-26
 
-## Languages & Runtime
+## Languages
 
-- **TypeScript** 5.8.3 — all source in `src/` (`tsconfig.json`)
-- **Node.js** >= 18 (`package.json` `engines`, `.nvmrc` pins `lts/*`)
-- **ESM-first** — `"type": "module"`; ships both ESM (`dist/index.js`) and CJS (`dist/index.cjs`) bundles
+**Primary:**
+- TypeScript 5.9.3 (`package.json` `devDependencies.typescript`, `tsconfig.json`) - library source under `src/` (`src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`, `src/index.ts`, `src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`) and tests in `test/index.test.ts`. Strict ESM (`package.json` `"type": "module"`). Compiler is strict with `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters` (`tsconfig.json`).
+- TypeScript 5.8.3 (`examples/next13-simple/package.json`, `examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`) - versioned Next.js demo apps.
 
-## Package Manager
+**Secondary:**
+- JavaScript / JSX - Next.js example pages and configs (`examples/next13-simple/next.config.js`, `examples/next14-app/next.config.mjs`, `examples/next14-app/postcss.config.js`, `examples/next14-app/tailwind.config.js`).
+- YAML - OpenAPI schema dumps and CI (`examples/next13-simple/models/openapi/company.swagger.yaml`, `examples/next13-simple/models/openapi/organization.swagger.yaml`, `examples/next13-simple/models/openapi/people.swagger.yaml`, `.github/workflows/codeql-analysis.yml`, `.github/workflows/codesee-arch-diagram.yml`, `.pre-commit-config.yaml`).
+- JSON - library and example config (`package.json`, `biome.json`, `renovate.json`, `cspell.json`, `examples/next13-simple/next-swagger-doc.json`, `examples/next13-simple/public/swagger.json`).
+- CSS - Swagger UI stylesheet imports (`examples/next14-app/app/api-doc/react-swagger.tsx`) and Tailwind globals (`examples/next14-app/styles/globals.css`, `examples/next15-app/styles/globals.css`, `examples/next16-app/styles/globals.css`).
+- OpenAPI 3.0.0 YAML/JSON - generated and hand-written specs (`src/swagger.ts` default `definition.openapi`, `examples/next13-simple/public/swagger.json`).
 
-- **pnpm** 10.9.0 (`packageManager` field, `pnpm-lock.yaml`)
+## Runtime
 
-## Build & Tooling
+**Environment:**
+- Node.js >= 18 (`package.json` `engines.node`, `AGENTS.md`, `README.md` badge). Next.js 16 example requires Node.js >= 20.9.0 (`examples/next16-app/package.json` `engines`, `AGENTS.md`).
+- Dual publish: ESM `dist/index.js` + CJS `dist/index.cjs` with types `dist/index.d.ts` (`package.json` `exports` / `main` / `module` / `types`). CLI bin `next-swagger-doc-cli` → `dist/cli.js` (`package.json` `bin`).
 
-| Tool | Version | Purpose |
-| --- | --- | --- |
-| pkgroll | 2.12.1 | Bundler — `pnpm build` / `pnpm start --watch`; emits `dist/index.cjs`, `dist/index.js`, `dist/index.d.ts`, `dist/cli.js` |
-| TypeScript | 5.8.3 | Type checking (`tsconfig.json`, strict) |
-| Biome | 1.9.4 | Lint + format (`biome.json`, `pnpm lint`, `pnpm format`) |
-| Vitest | 3.1.2 | Unit tests (`vitest.config.ts`, `pnpm test`) |
-| typedoc | 0.28.3 | API docs (`pnpm vercel-build` runs `typedoc src/index.ts`) |
-| size-limit | 11.2.0 | Declared devDependency — **no config file found** (unused) |
-| c8 / @vitest/coverage-v8 | 10.1.3 / 3.1.2 | Coverage (`pnpm coverage`) |
+**Package Manager:**
+- pnpm 10.34.5 via Corepack (`package.json` `packageManager`, `AGENTS.md`).
+- Lockfile: present — root `pnpm-lock.yaml` (`lockfileVersion: '9.0'`). Example apps have separate lockfiles (`examples/next13-simple/pnpm-lock.yaml`, `examples/next14-app/pnpm-lock.yaml`, `examples/next15-app/pnpm-lock.yaml`, `examples/next16-app/pnpm-lock.yaml`) and pin `pnpm@10.8.0` (`examples/next13-simple/package.json`, `examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`).
+- `pnpm.onlyBuiltDependencies`: `@biomejs/biome`, `esbuild`, `sharp` (`package.json`).
 
-## Runtime Dependencies
+## Frameworks
 
-| Package | Version | Role |
-| --- | --- | --- |
-| swagger-jsdoc | 6.2.8 | Core engine — parses JSDoc `@swagger` annotations into an OAS3 spec |
-| cleye | 1.3.4 | CLI argument parsing (`src/cli.ts`) |
-| es-module-lexer | 2.3.2 | Real ESM lexer — extracts exported HTTP handlers from route source (`src/route-parser.ts`) |
-| isarray | 2.0.5 | Array check helper |
-| @types/swagger-jsdoc | 6.0.4 | Types for swagger-jsdoc |
+**Core:**
+- Next.js peer `>=9` (`package.json` `peerDependencies`); library types import `NextApiRequest` / `NextApiResponse` (`src/swagger.ts`). Dev dependency Next.js 16.3.3 (`package.json`). Example apps stay on their lines: Next.js 13.5.6 Pages Router (`examples/next13-simple/package.json`), Next.js ^14.2.26 App Router (`examples/next14-app/package.json`), Next.js ^15.3.0 App Router (`examples/next15-app/package.json`), Next.js ^16.1.5 App Router (`examples/next16-app/package.json`, `AGENTS.md`).
+- React 18.3.1 (`examples/next13-simple/package.json`, `examples/next14-app/package.json`) and React 19.1.0 (`examples/next15-app/package.json`, `examples/next16-app/package.json`) — demo UIs only; the library itself is not a React component (`src/index.ts` exports `./auto-doc` and `./swagger` only).
+- swagger-jsdoc 6.3.0 (`package.json` `dependencies`, `src/swagger.ts`) — parses `@swagger` JSDoc into an OAS3 document.
+- OpenAPI 3.0.0 (`src/swagger.ts` `defaultOptions.definition`, `README.md`) — output spec format, not a runtime framework.
 
-## Peer Dependency
+**Testing:**
+- Vitest 3.2.7 (`package.json` `scripts.test` = `vitest run`, `vitest.config.ts` `test.globals: true`). Tests live in `test/index.test.ts` with snapshots in `test/__snapshots__/index.test.ts.snap` and fixtures under `test/fixtures/` (`AGENTS.md`).
+- @vitest/coverage-v8 3.2.7 (`package.json` `scripts.coverage` = `vitest run --coverage`).
+- @vitest/ui 3.2.7 (`package.json` `scripts.test:ui`).
+- c8 10.1.3 (`package.json`) — listed but coverage is wired through Vitest V8, not a separate `c8` script.
 
-- **next** >= 9 — the library targets Next.js API routes (pages router and App Router)
+**Build/Dev:**
+- pkgroll 2.27.1 (`package.json` `scripts.build` / `prepare` / `start`) — bundles `src/` to `dist/` (do not edit `dist/`; `AGENTS.md`).
+- TypeScript 5.9.3 (`package.json`, `tsconfig.json`) — `noEmit: true`; emit is pkgroll’s job.
+- Biome 1.9.4 (`package.json` `scripts.lint` / `format`, `biome.json`) — 2-space indent, 80-column width, single quotes, lint+format `src` (`AGENTS.md`).
+- Vite 6.4.3 (`package.json`) — Vitest runner.
+- pre-commit (`README.md`, `.pre-commit-config.yaml`) — Prettier for HTML/CSS/Markdown; Biome check with `@biomejs/biome@1.7.0`.
+- cspell (`cspell.json`, `cspell-tool.txt`) — English spellcheck dictionary.
+- TypeDoc 0.28.20 (`package.json` `scripts.vercel-build` = `npx typedoc src/index.ts`) — API docs site.
+- bumpp 12.2.2 (`package.json` `scripts.release:version`) — conventional version/tag/push.
+- size-limit 11.2.0 (`package.json`) — listed; no `size-limit` config or script found.
+- @skypack/package-check 0.2.2, sort-package-json 3.7.1, all-contributors-cli 6.26.1, tslib 2.8.1 (`package.json`).
+- Example UI: Tailwind CSS ^3.4.14 + PostCSS + Autoprefixer (`examples/next14-app/package.json`, `examples/next14-app/tailwind.config.js`, `examples/next14-app/postcss.config.js`; same pattern in `examples/next15-app/` and `examples/next16-app/`).
+- Example UI: styled-components 6.1.17 + @xstyled (`examples/next13-simple/package.json`, `examples/next13-simple/next.config.js`).
+- Example UI: Radix UI, lucide-react, next-themes, class-variance-authority, clsx, tailwind-merge (`examples/next14-app/package.json`, `examples/next14-app/components/theme-provider.tsx`).
+- Example schema helper: typeconv 2.3.1 + cpy-cli 5.0.0 (`examples/next13-simple/package.json` `openapi:yaml` / `postbuild`).
+- Example local linking: `examples/next13-simple/link.config.json` points `packages` at `../`.
 
-## Dev Dependencies (notable)
+## Key Dependencies
 
-- `next` 15.3.1 (used by tests/examples), `@types/node` 22.14.1, `all-contributors-cli`, `sort-package-json`, `@vitest/ui`, `tslib`
+**Critical:**
+- swagger-jsdoc 6.3.0 (`package.json`, `src/swagger.ts`) — core JSDoc `@swagger` → OpenAPI conversion used by `createSwaggerSpec`.
+- @types/swagger-jsdoc 6.0.4 (`package.json`) — `OAS3Definition` / `Options` types in `src/swagger.ts`.
+- es-module-lexer 2.3.2 (`package.json`, `src/route-parser.ts`) — WASM lexer extracts exported HTTP handlers (`GET`/`POST`/…) from `route.ts` without regex sanitisation; `initSync()` at module load.
+- cleye 1.3.4 (`package.json`, `src/cli.ts`) — CLI argv for `next-swagger-doc-cli` (`<config file>`, `--output`).
+- next >= 9 (peer) (`package.json`, `src/swagger.ts`) — `withSwagger` Pages Router handler types; App Router support is filesystem-based, not a Next.js plugin.
+- isarray 2.0.5 (`package.json`) — declared runtime dependency; no import in `src/` (also listed in `examples/next13-simple/package.json`).
+- Node built-ins `node:fs` / `node:path` (`src/swagger.ts`, `src/auto-doc.ts`, `src/spec-source.ts`, `src/cli.ts`) — scan API folders, `.next/server`, and `public/`; write `outputFile`.
 
-## Configuration Files
+**Infrastructure:**
+- swagger-ui-react (examples only: `latest` in `examples/next13-simple/package.json`; ^5.20.8 in `examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`) — demo Swagger UI; not a library dependency (`README.md`, `AGENTS.md`). Loaded via `next/dynamic` with `ssr: false` (`examples/next14-app/app/api-doc/react-swagger.tsx`, `examples/next13-simple/pages/api-doc.tsx`).
+- @stoplight/elements 9.0.1 (`examples/next13-simple/package.json`, `examples/next13-simple/pages/playground.tsx`) — alternate OpenAPI viewer demo.
+- openapi-types ^12.1.3 (`examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`) — example typing only.
+- sharp ^0.34.1 (`examples/next14-app/package.json` and later examples) — Next.js image pipeline in demos.
+- Git (`biome.json` `vcs.clientKind`, `.pre-commit-config.yaml`) — VCS for Biome ignore file and hooks.
 
-| File | Purpose |
-| --- | --- |
-| `tsconfig.json` | Strict TS config; `noEmit`, declaration + sourceMap output via pkgroll |
-| `biome.json` | Lint rules (recommended off, curated rule sets) + formatter (2-space, single quotes, 80 cols) |
-| `vitest.config.ts` | Test config — `globals: true` |
-| `.nvmrc` | Node `lts/*` |
-| `renovate.json` | Dependency updates — auto-merge non-major, lockfile maintenance |
-| `cspell.json` + `cspell-tool.txt` | Spell-check dictionary |
-| `.pre-commit-config.yaml` | Prettier (html/css/markdown) + Biome pre-commit hooks |
-| `.changie.yaml` | Changelog generation (fragments in `.changes/`) |
-| `.gitignore` | Ignores `node_modules`, `dist`, `coverage`, `docs`, `.vercel` |
+## Configuration
 
-## Package Entry Points
+**Environment:**
+- No `.env`, `.env.example`, or required user secrets in the library. Runtime reads Next.js-injected vars only (`src/swagger.ts`): `process.env.NEXT_PHASE` (skip globbing `.next` during `phase-production-build` / `phase-production-compile` / `phase-export`) and `process.env.__NEXT_ROUTER_BASEPATH` (optional OpenAPI `servers[0].url`).
+- Examples read `process.env.NODE_ENV` to hide the Tailwind breakpoint indicator (`examples/next14-app/components/tailwind-indicator.tsx`, `examples/next15-app/components/tailwind-indicator.tsx`, `examples/next16-app/components/tailwind-indicator.tsx`).
+- Library options are code/JSON, not env: `apiFolder` (default `pages/api`), `schemaFolders`, `definition`, `autoDoc`, `specFile`, `outputFile`, `scanBuildOutput` (`src/swagger.ts` `SwaggerOptions`; CLI config `examples/next13-simple/next-swagger-doc.json`).
+- GitHub Actions secret `CODESEE_ARCH_DIAG_API_TOKEN` (`.github/workflows/codesee-arch-diagram.yml`) — CodeSee only, not app runtime.
 
-- `exports`: `require` → `dist/index.cjs`, `import` → `dist/index.js`
-- `types`/`typings` → `dist/index.d.ts`
-- `bin`: `next-swagger-doc-cli` → `dist/cli.js`
-- Published files: `dist` + `src`
+**Build:**
+- `tsconfig.json` — `module: esnext`, `moduleResolution: node`, `jsx: react`, `strict: true`, `noEmit: true`, `rootDir: ./src`, `importHelpers: true`.
+- `biome.json` — formatter (spaces, width 80, LF, single quotes) and linter rules; ignores `dist`.
+- `vitest.config.ts` — `globals: true`.
+- `package.json` scripts: `build`/`prepare`/`start` (pkgroll), `test`/`coverage`/`test:ui` (Vitest), `lint`/`format` (Biome), `vercel-build` (TypeDoc), `release:version` (bumpp).
+- Example Next configs: `examples/next13-simple/next.config.js` (styled-components compiler, `removeConsole`); `examples/next14-app/next.config.mjs` and `examples/next15-app/next.config.mjs` (`reactStrictMode`, transpile `swagger-ui-react` / `swagger-client` / `react-syntax-highlighter`); `examples/next16-app/next.config.mjs` adds `turbopack.root`.
+- Example TS configs: `examples/next13-simple/tsconfig.json` (`strict: false`); `examples/next14-app/tsconfig.json` (`strict: true`, `moduleResolution: node`); `examples/next16-app/tsconfig.json` (`moduleResolution: bundler`, `jsx: react-jsx`, `target: ES2017`).
+- `renovate.json` — `config:base`, pin all except peers, lockfile maintenance, automerge non-major.
+- `cspell.json` — custom dictionary `cspell-tool.txt`.
+- `.pre-commit-config.yaml` — Prettier + Biome.
+- No `vercel.json`, `typedoc.json`, or `size-limit` config file in the repo.
 
-## Scripts
+## Platform Requirements
 
-| Script | Command |
-| --- | --- |
-| `build` / `prepare` | `pkgroll` |
-| `start` | `pkgroll --watch` |
-| `test` | `vitest run` |
-| `test:ui` | `vitest --ui` |
-| `coverage` | `vitest run --coverage` |
-| `lint` | `biome lint src` |
-| `format` | `biome format src` |
-| `vercel-build` | `npx typedoc src/index.ts` |
+**Development:**
+- Node.js >= 18; Corepack + `pnpm@10.34.5 install --frozen-lockfile` (`AGENTS.md`, `package.json`). Next.js 16 example: Node.js >= 20.9 (`examples/next16-app/package.json`).
+- Commands: `pnpm test`, `pnpm coverage`, `pnpm lint`, `pnpm format`, `pnpm build` (`AGENTS.md`, `package.json`).
+- Optional: `pre-commit install` (`README.md`).
+- No extra services (databases, queues, local docker) — `AGENTS.md` states `.agents/setup` is install-only.
+- Library verified with `pnpm test` at repo root, not by rewriting example lockfiles (`AGENTS.md`).
+
+**Production:**
+- Published npm package `next-swagger-doc` 0.5.0 (`package.json`, `README.md` npm badges). Consumers embed it in a Next.js app (>=9) and optionally ship `public/swagger.json` for `output: 'standalone'` (`README.md`, `src/swagger.ts` `specFile` / `outputFile`).
+- CLI generate-at-build: `next-swagger-doc-cli next-swagger-doc.json --output public/swagger.json` (`src/cli.ts` default output `public/swagger.json`, `README.md`).
+- Docs site: TypeDoc via `vercel-build` (`package.json`); homepage `https://next-swagger-doc.productsway.com/` (`README.md`). Demo `https://next-swagger-doc-demo.productsway.com/api-doc` (`README.md`). Vercel is the documented Next.js deploy target (`examples/next13-simple/README.md`) and a build constraint (do not glob `.next` during compile; `src/swagger.ts`, `AGENTS.md`).
+- MIT license (`LICENSE`, `package.json`).
+
+---
+
+*Stack analysis: 2026-08-26*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -5,7 +5,7 @@
 ## Languages
 
 **Primary:**
-- TypeScript 5.9.3 (`package.json` `devDependencies.typescript`, `tsconfig.json`) - library source under `src/` (`src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`, `src/index.ts`, `src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`) and tests in `test/index.test.ts`. Strict ESM (`package.json` `"type": "module"`). Compiler is strict with `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters` (`tsconfig.json`).
+- TypeScript 7.0.2 (`package.json` `devDependencies.typescript`, `tsconfig.json`) - library source under `src/` (`src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`, `src/index.ts`, `src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`) and tests in `test/index.test.ts`. Strict ESM (`package.json` `"type": "module"`). Compiler is strict with `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters` (`tsconfig.json`).
 - TypeScript 5.8.3 (`examples/next13-simple/package.json`, `examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`) - versioned Next.js demo apps.
 
 **Secondary:**
@@ -22,7 +22,7 @@
 - Dual publish: ESM `dist/index.js` + CJS `dist/index.cjs` with types `dist/index.d.ts` (`package.json` `exports` / `main` / `module` / `types`). CLI bin `next-swagger-doc-cli` → `dist/cli.js` (`package.json` `bin`).
 
 **Package Manager:**
-- pnpm 10.34.5 via Corepack (`package.json` `packageManager`, `AGENTS.md`).
+- pnpm 11.24.0 via Corepack (`package.json` `packageManager`). `AGENTS.md` still documents pnpm 10.34.5.
 - Lockfile: present — root `pnpm-lock.yaml` (`lockfileVersion: '9.0'`). Example apps have separate lockfiles (`examples/next13-simple/pnpm-lock.yaml`, `examples/next14-app/pnpm-lock.yaml`, `examples/next15-app/pnpm-lock.yaml`, `examples/next16-app/pnpm-lock.yaml`) and pin `pnpm@10.8.0` (`examples/next13-simple/package.json`, `examples/next14-app/package.json`, `examples/next15-app/package.json`, `examples/next16-app/package.json`).
 - `pnpm.onlyBuiltDependencies`: `@biomejs/biome`, `esbuild`, `sharp` (`package.json`).
 
@@ -35,15 +35,15 @@
 - OpenAPI 3.0.0 (`src/swagger.ts` `defaultOptions.definition`, `README.md`) — output spec format, not a runtime framework.
 
 **Testing:**
-- Vitest 3.2.7 (`package.json` `scripts.test` = `vitest run`, `vitest.config.ts` `test.globals: true`). Tests live in `test/index.test.ts` with snapshots in `test/__snapshots__/index.test.ts.snap` and fixtures under `test/fixtures/` (`AGENTS.md`).
-- @vitest/coverage-v8 3.2.7 (`package.json` `scripts.coverage` = `vitest run --coverage`).
-- @vitest/ui 3.2.7 (`package.json` `scripts.test:ui`).
+- Vitest 4.1.11 (`package.json` `scripts.test` = `vitest run`, `vitest.config.ts` `test.globals: true`). Tests live in `test/index.test.ts` with snapshots in `test/__snapshots__/index.test.ts.snap` and fixtures under `test/fixtures/` (`AGENTS.md`).
+- @vitest/coverage-v8 4.1.11 (`package.json` `scripts.coverage` = `vitest run --coverage`).
+- @vitest/ui 4.1.11 (`package.json` `scripts.test:ui`).
 - c8 10.1.3 (`package.json`) — listed but coverage is wired through Vitest V8, not a separate `c8` script.
 
 **Build/Dev:**
 - pkgroll 2.27.1 (`package.json` `scripts.build` / `prepare` / `start`) — bundles `src/` to `dist/` (do not edit `dist/`; `AGENTS.md`).
-- TypeScript 5.9.3 (`package.json`, `tsconfig.json`) — `noEmit: true`; emit is pkgroll’s job.
-- Biome 1.9.4 (`package.json` `scripts.lint` / `format`, `biome.json`) — 2-space indent, 80-column width, single quotes, lint+format `src` (`AGENTS.md`).
+- TypeScript 7.0.2 (`package.json`, `tsconfig.json`) — `noEmit: true`; emit is pkgroll’s job.
+- Biome 2.5.10 (`package.json` `scripts.lint` / `format`, `biome.json`) — 2-space indent, 80-column width, single quotes, lint+format `src` (`AGENTS.md`).
 - Vite 6.4.3 (`package.json`) — Vitest runner.
 - pre-commit (`README.md`, `.pre-commit-config.yaml`) — Prettier for HTML/CSS/Markdown; Biome check with `@biomejs/biome@1.7.0`.
 - cspell (`cspell.json`, `cspell-tool.txt`) — English spellcheck dictionary.
@@ -63,7 +63,7 @@
 - swagger-jsdoc 6.3.0 (`package.json`, `src/swagger.ts`) — core JSDoc `@swagger` → OpenAPI conversion used by `createSwaggerSpec`.
 - @types/swagger-jsdoc 6.0.4 (`package.json`) — `OAS3Definition` / `Options` types in `src/swagger.ts`.
 - es-module-lexer 2.3.2 (`package.json`, `src/route-parser.ts`) — WASM lexer extracts exported HTTP handlers (`GET`/`POST`/…) from `route.ts` without regex sanitisation; `initSync()` at module load.
-- cleye 1.3.4 (`package.json`, `src/cli.ts`) — CLI argv for `next-swagger-doc-cli` (`<config file>`, `--output`).
+- cleye 2.6.0 (`package.json`, `src/cli.ts`) — CLI argv for `next-swagger-doc-cli` (`<config file>`, `--output`).
 - next >= 9 (peer) (`package.json`, `src/swagger.ts`) — `withSwagger` Pages Router handler types; App Router support is filesystem-based, not a Next.js plugin.
 - isarray 2.0.5 (`package.json`) — declared runtime dependency; no import in `src/` (also listed in `examples/next13-simple/package.json`).
 - Node built-ins `node:fs` / `node:path` (`src/swagger.ts`, `src/auto-doc.ts`, `src/spec-source.ts`, `src/cli.ts`) — scan API folders, `.next/server`, and `public/`; write `outputFile`.
@@ -98,7 +98,7 @@
 ## Platform Requirements
 
 **Development:**
-- Node.js >= 18; Corepack + `pnpm@10.34.5 install --frozen-lockfile` (`AGENTS.md`, `package.json`). Next.js 16 example: Node.js >= 20.9 (`examples/next16-app/package.json`).
+- Node.js >= 18. `package.json` pins pnpm 11.24.0 while `AGENTS.md` still documents `pnpm@10.34.5 install --frozen-lockfile`. Next.js 16 example: Node.js >= 20.9 (`examples/next16-app/package.json`).
 - Commands: `pnpm test`, `pnpm coverage`, `pnpm lint`, `pnpm format`, `pnpm build` (`AGENTS.md`, `package.json`).
 - Optional: `pre-commit install` (`README.md`).
 - No extra services (databases, queues, local docker) — `AGENTS.md` states `.agents/setup` is install-only.

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,69 +1,197 @@
-# STRUCTURE — next-swagger-doc
+# Codebase Structure
+
+**Analysis Date:** 2026-08-26
 
 ## Directory Layout
 
 ```
-.
-├── src/                        # Library source (TypeScript, ESM)
-│   ├── index.ts                # Public entry — re-exports auto-doc + swagger
-│   ├── swagger.ts              # createSwaggerSpec, withSwagger, SwaggerOptions
-│   ├── auto-doc.ts             # extractApiInfo, generateAutoDoc (App Router)
-│   ├── route-parser.ts         # getExportedMethods via es-module-lexer
-│   └── cli.ts                  # next-swagger-doc-cli binary (cleye)
-├── test/
-│   ├── index.test.ts           # All unit tests (Vitest)
-│   ├── __snapshots__/          # Vitest snapshots for spec generation
-│   └── fixtures/               # Test fixtures
-│       ├── app/                # App Router route fixtures (route.ts files)
-│       │   ├── api/{health,manual,regex,users/[id],users}/
-│       │   ├── blog/[[...slug]]/
-│       │   ├── users/
-│       │   └── commented/
-│       └── .next/server/app/   # Compiled route.js fixtures (build-dir scanning)
-│           ├── only-compiled/compiled/route.js
-│           └── api/compiled/route.js
-├── examples/                   # Runnable demo apps (not published)
-│   ├── next13-simple/          # Pages Router demo (pages/api, models/, CLI config)
-│   ├── next14-app/             # App Router demo (app/api, app/api-doc, swagger-ui-react)
-│   └── next15-app/             # App Router demo (same shape as next14-app, Next 15 + React 19)
-├── .github/
-│   ├── workflows/              # codeql-analysis.yml, codesee-arch-diagram.yml
-│   └── FUNDING.yml
-├── .changes/                   # Changie changelog fragments (unreleased/)
-├── .swm/                       # Swimm docs (testing-overview, dev-environment-setup)
-├── .agents/                    # Agent config files (setup, resume)
-└── Root config files           # package.json, tsconfig.json, biome.json, vitest.config.ts,
-                                # renovate.json, cspell.json, .pre-commit-config.yaml,
-                                # .changie.yaml, .nvmrc, .gitignore
+codemap/  # next-swagger-doc — OpenAPI spec generator for Next.js API routes
+├── src/  # Library TypeScript source (strict ESM); pkgroll compiles to dist/
+│   ├── index.ts  # Public barrel: re-exports auto-doc + swagger
+│   ├── swagger.ts  # createSwaggerSpec, withSwagger, SwaggerOptions, scan policy
+│   ├── auto-doc.ts  # Walk route files, extract ApiInfo, generate operations
+│   ├── cli.ts  # next-swagger-doc-cli entry (cleye)
+│   ├── merge-auto-doc.ts  # Manual JSDoc operations win over generated
+│   ├── route-parser.ts  # es-module-lexer HTTP method export detection
+│   ├── route-path.ts  # Next.js folder segments → OpenAPI paths
+│   └── spec-source.ts  # sourceDirs / .next/server buildDirs / publicDir
+├── test/  # Vitest tests, snapshots, and App Router fixtures
+│   ├── index.test.ts  # All library tests (snapshots + unit)
+│   ├── __snapshots__/index.test.ts.snap  # createSwaggerSpec snapshots
+│   └── fixtures/
+│       ├── app/  # Source App Router route.* fixtures
+│       └── .next/server/app/only-compiled/  # Compiled-only fallback fixture
+├── examples/  # Versioned Next.js demo apps (own lockfiles; published package)
+│   ├── next13-simple/  # Next.js 13 Pages Router + models/schemaFolders + CLI
+│   ├── next14-app/  # Next.js 14 App Router + swagger-ui-react
+│   ├── next15-app/  # Next.js 15 App Router (same layout as 14)
+│   └── next16-app/  # Next.js 16 App Router (Node >= 20.9)
+├── .agents/  # Agent setup/resume scripts
+├── .github/  # FUNDING.yml and GitHub Actions (CodeQL, CodeSee)
+├── .planning/codebase/  # Architecture/structure notes (this folder)
+├── AGENTS.md  # Agent instructions for this repo
+├── biome.json  # Format + lint for src (2-space, 80-col)
+├── CHANGELOG.md  # Keep a Changelog / Changie
+├── cspell.json  # Spellcheck config
+├── cspell-tool.txt  # Project dictionary
+├── LICENSE  # MIT
+├── package.json  # Library package, scripts, exports, bin
+├── pnpm-lock.yaml  # Root lockfile (pnpm 10.34.5)
+├── README.md  # Usage (App Router, Pages, API route, CLI)
+├── renovate.json  # Dependency update policy
+├── SECURITY.md  # Vulnerability reporting
+├── tsconfig.json  # Strict TS, rootDir src, noEmit
+├── vitest.config.ts  # Vitest globals
+└── example-screenshot.png  # README screenshot
 ```
 
-## Key Locations
+## Directory Purposes
 
-| Location | What lives there |
-| --- | --- |
-| `src/index.ts` | Public API surface (barrel) |
-| `src/swagger.ts` | Main spec-generation logic + Next middleware |
-| `src/auto-doc.ts` | App Router auto-documentation feature |
-| `src/route-parser.ts` | Route source parser (es-module-lexer) |
-| `src/cli.ts` | CLI entry (`bin` target) |
-| `test/fixtures/` | Route files used to test extraction/generation |
-| `examples/` | Three standalone Next.js apps demonstrating usage |
+**src/:**
+- Purpose: All library implementation. Do not edit `dist/`; pkgroll writes it from here (`package.json` `build`/`prepare`).
+- Contains: Eight `.ts` modules, no subpackages, no React UI.
+- Key files: `src/index.ts`, `src/swagger.ts`, `src/auto-doc.ts`, `src/cli.ts`, `src/merge-auto-doc.ts`, `src/route-parser.ts`, `src/route-path.ts`, `src/spec-source.ts`
+
+**test/:**
+- Purpose: Vitest coverage of public and internal helpers using real route fixtures rather than mocks (`AGENTS.md`).
+- Contains: One test file, one snapshot, App Router `route.ts` trees, and a compiled `.next` fallback.
+- Key files: `test/index.test.ts`, `test/fixtures/app/api/health/route.ts`, `test/fixtures/app/api/manual/route.ts`, `test/fixtures/app/api/regex/route.ts`, `test/fixtures/app/api/users/[id]/route.ts`, `test/fixtures/app/blog/[[...slug]]/route.ts`, `test/fixtures/app/commented/route.ts`, `test/fixtures/app/users/route.ts`, `test/fixtures/.next/server/app/only-compiled/compiled/route.js`
+
+**examples/:**
+- Purpose: Version-locked demos. Depend on published `next-swagger-doc` (GitHub tag in their `package.json`), not workspace linking. Do not bump 13/14/15 examples to 16.
+- Contains: Four independent Next.js apps with their own `pnpm-lock.yaml`.
+- Key files: `examples/next13-simple/pages/api/doc.ts`, `examples/next13-simple/next-swagger-doc.json`, `examples/next14-app/lib/swagger.ts`, `examples/next14-app/app/api/hello/route.ts`, `examples/next16-app/next.config.mjs`
+
+**examples/next13-simple/:**
+- Purpose: Pages Router sample: `withSwagger` API, `createSwaggerSpec` in `getStaticProps`, `schemaFolders: ['models']`, CLI-generated `public/swagger.json`, Stoplight playground.
+- Contains: `pages/`, `models/` (+ `models/openapi/*.swagger.yaml` from typeconv), `public/swagger.json`.
+- Key files: `examples/next13-simple/pages/api/hello.ts`, `examples/next13-simple/pages/api/organization.tsx`, `examples/next13-simple/pages/api-doc.tsx`, `examples/next13-simple/pages/swagger.tsx`, `examples/next13-simple/pages/playground.tsx`, `examples/next13-simple/models/organization.ts`
+
+**examples/next14-app/, next15-app/, next16-app/:**
+- Purpose: App Router samples sharing the same shape: `app/api/hello/route.ts` with `@swagger`, `lib/swagger.ts` (`apiFolder: 'app/api'`, `specFile: 'public/swagger.json'`, `autoDoc: true`), client `app/api-doc/react-swagger.tsx`.
+- Contains: shadcn-style `components/`, Tailwind `styles/`, `config/site.ts`.
+- Key files: `examples/next14-app/app/api-doc/page.tsx`, `examples/next14-app/app/api-doc/react-swagger.tsx`, `examples/next16-app/lib/swagger.ts`
+
+**.agents/:**
+- Purpose: Automated setup for coding agents.
+- Contains: `setup` (Corepack + pnpm install), `resume`.
+- Key files: `.agents/setup`
+
+**.github/:**
+- Purpose: GitHub metadata and CI.
+- Contains: `FUNDING.yml`, `workflows/codeql-analysis.yml`, `workflows/codesee-arch-diagram.yml`.
+- Key files: `.github/workflows/codeql-analysis.yml`
+
+**.planning/codebase/:**
+- Purpose: Generated architecture/structure documentation for planning.
+- Contains: `ARCHITECTURE.md`, `STRUCTURE.md`.
+- Key files: `.planning/codebase/ARCHITECTURE.md`, `.planning/codebase/STRUCTURE.md`
+
+## Key File Locations
+
+**Entry Points:**
+- `src/index.ts`: Package public API (`export *` from auto-doc and swagger).
+- `src/swagger.ts`: `createSwaggerSpec` and `withSwagger` — main runtime entry.
+- `src/cli.ts`: `next-swagger-doc-cli` (published as `dist/cli.js` via `package.json` `bin`).
+- `package.json`: Dual ESM/CJS `exports`, `main`/`module`/`types` pointing at `dist/`, `files: ["dist", "src"]`.
+
+**Configuration:**
+- `package.json`: Scripts (`build` pkgroll, `test` vitest, `lint`/`format` biome), engines `node >= 18`, peer `next >= 9`, packageManager `pnpm@10.34.5`.
+- `tsconfig.json`: `include: ["src", "types"]`, `strict`, `noEmit`, `rootDir: ./src`, `module: esnext`.
+- `vitest.config.ts`: `{ test: { globals: true } }`.
+- `biome.json`: Formatter (2-space, 80-col, single quotes for JS) and lint rules scoped to `src`; ignores `dist`.
+- `renovate.json`: Pin non-peer deps, automerge non-major.
+- `cspell.json` / `cspell-tool.txt`: Spellcheck dictionary.
+- `.pre-commit-config.yaml`: prettier (html/css/md) + biome-check.
+- `.gitignore`: `node_modules`, `dist`, `coverage`, `docs`, `.vercel`.
+- `examples/next13-simple/next-swagger-doc.json`: CLI config (`apiFolder`, `schemaFolders`, `definition`).
+- `examples/*/next.config.mjs` (or `.js`): App Router examples transpile `swagger-ui-react`; next16 sets `turbopack.root`.
+
+**Core Logic:**
+- `src/swagger.ts`: Options types, specFile load, glob assembly, NEXT_PHASE scan gate, swagger-jsdoc invocation, auto-doc merge, outputFile write, Pages middleware.
+- `src/auto-doc.ts`: `extractApiInfo` / `generateAutoDoc` / path-parameter extraction.
+- `src/spec-source.ts`: `discoverSpecLocations`.
+- `src/route-path.ts`: `routeToOpenApiPaths` (groups, parallel routes, dynamic/catch-all).
+- `src/route-parser.ts`: `HTTP_METHODS`, `getExportedMethods`.
+- `src/merge-auto-doc.ts`: `mergeAutoDoc`.
+
+**Testing:**
+- `test/index.test.ts`: Snapshots for default/Bearer/OAuth2 specs; `extractApiInfo` on fixtures; autoDoc vs manual; scan policy temp dirs; `specFile`/`outputFile`; `routeToOpenApiPaths`; `discoverSpecLocations`; `mergeAutoDoc`.
+- `test/__snapshots__/index.test.ts.snap`: Expected OAS3 JSON for snapshot cases.
+- `test/fixtures/`: Real `route.ts` trees (no mocks).
 
 ## Naming Conventions
 
-- **Files**: `kebab-case` for source/config (`auto-doc.ts`, `next-swagger-doc.json`); `route.ts` / `page.tsx` per Next.js conventions inside examples
-- **Functions**: `camelCase`, verb-first for actions (`extractApiInfo`, `generateAutoDoc`, `createSwaggerSpec`, `getRouteFiles`)
-- **Types/Interfaces**: `PascalCase` (`ApiInfo`, `SwaggerOptions`, `AutoDocOptions`)
-- **Constants**: `UPPER_SNAKE_CASE` (`HTTP_METHODS`, `defaultOptions`)
-- **Exports**: named exports throughout; no default exports in the library (`src/`)
-- **Tests**: single `index.test.ts` with `describe('withSwagger', …)` suites; fixtures mirror real Next.js app structure
+**Files:**
+- kebab-case TypeScript modules in `src/`: `auto-doc.ts`, `merge-auto-doc.ts`, `route-parser.ts`, `route-path.ts`, `spec-source.ts`.
+- Next.js App Router convention `route.ts` under `app/**` in examples and fixtures.
+- Next.js Pages API files named after the path: `examples/next13-simple/pages/api/hello.ts`, `doc.ts`, `organization.tsx`.
+- Example swagger helpers: `lib/swagger.ts`; UI wrapper: `app/api-doc/react-swagger.tsx`.
+- Schema sidecars: `*.swagger.yaml` under `examples/next13-simple/models/openapi/`.
+- Tests: single `index.test.ts` plus `__snapshots__/index.test.ts.snap`.
 
-## Entry Points
+**Directories:**
+- `src/`, `test/`, `examples/` at repo root.
+- Example folders `next{13,14,15,16}-{simple|app}` keep each Next.js major on its line.
+- Fixtures mirror App Router trees: `test/fixtures/app/api/users/[id]/`, `test/fixtures/app/blog/[[...slug]]/`.
+- Dynamic segments use Next.js bracket names (`[id]`, `[[...slug]]`), not OpenAPI `{id}` on disk.
 
-- **Library**: `src/index.ts` → `dist/index.js` (ESM) / `dist/index.cjs` (CJS), types `dist/index.d.ts`
-- **CLI**: `src/cli.ts` → `dist/cli.js` (`next-swagger-doc-cli`)
-- **Docs**: `typedoc src/index.ts` (via `vercel-build`)
+## Where to Add New Code
 
-## Generated / Ignored
+**New Feature:**
+- Primary code: `src/` — orchestration and options on `src/swagger.ts` (`SwaggerOptions`); App Router inference in `src/auto-doc.ts` or a new sibling module imported from there. Document new options on `SwaggerOptions` and in `README.md` (`AGENTS.md`).
+- Tests: `test/index.test.ts` plus real files under `test/fixtures/` (prefer fixtures over mocks). Update `test/__snapshots__/index.test.ts.snap` when `createSwaggerSpec` output changes.
 
-`dist/`, `node_modules/`, `coverage/`, `docs/`, `.vercel/` are gitignored. `tsconfig.tsbuildinfo` appears inside examples (not ignored there).
+**New Component/Module:**
+- Implementation: New `src/<kebab-name>.ts`. Export from `src/index.ts` only if it is a public API; keep helpers like `merge-auto-doc.ts` / `route-path.ts` internal and import them from tests by path if needed.
+- CLI flags: `src/cli.ts` (`cleye` `flags` / `parameters`).
+- Example-only UI: under the relevant `examples/next*-app/` app, not in `src/` (this package does not ship a viewer).
+
+**Utilities:**
+- Shared helpers: `src/spec-source.ts` (path layout), `src/route-path.ts` (folder conventions), `src/route-parser.ts` (export parsing), `src/merge-auto-doc.ts` (path merge). Keep them focused; do not dump helpers into `src/index.ts`.
+
+## Special Directories
+
+**dist/:**
+- Purpose: pkgroll build output (`index.js`, `index.cjs`, `index.d.ts`, `cli.js`). Published to npm.
+- Generated: Yes
+- Committed: No (`.gitignore`)
+
+**node_modules/:**
+- Purpose: pnpm-installed dependencies at repo root and in each example.
+- Generated: Yes
+- Committed: No
+
+**examples/*/ .next/ and test/fixtures/.next/:**
+- Purpose: Next.js compiled server output. The fixture under `test/fixtures/.next/server/app/only-compiled/` is a checked-in compiled `route.js` used when source is missing.
+- Generated: Example `.next/` is generated at `next build`. The compiled fixture is hand-authored for tests.
+- Committed: Example `.next/` no (per-example `.gitignore`). Fixture `.next` yes (needed for `extractApiInfo('app/only-compiled', 'test/fixtures')`).
+
+**coverage/:**
+- Purpose: `pnpm coverage` (Vitest + `@vitest/coverage-v8`) output.
+- Generated: Yes
+- Committed: No (`.gitignore`)
+
+**docs/:**
+- Purpose: TypeDoc output from `package.json` `vercel-build` (`npx typedoc src/index.ts`).
+- Generated: Yes
+- Committed: No (`.gitignore`)
+
+**examples/:**
+- Purpose: Independent demo apps; each has its own lockfile and depends on published `next-swagger-doc`.
+- Generated: No
+- Committed: Yes (except each app’s `node_modules`, `.next`, `coverage`)
+
+**test/fixtures/:**
+- Purpose: Real App Router route modules covering health, JSDoc-manual, regex-in-source, dynamic `[id]`, optional catch-all, commented exports, re-exported handlers, and compiled-only OPTIONS.
+- Generated: No
+- Committed: Yes
+
+**.planning/:**
+- Purpose: Planning/architecture artifacts for agents.
+- Generated: Written by analysis tasks
+- Committed: Depends on workflow; not listed in `.gitignore`
+
+---
+
+*Structure analysis: 2026-08-26*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -36,7 +36,7 @@ codemap/  # next-swagger-doc — OpenAPI spec generator for Next.js API routes
 ├── cspell-tool.txt  # Project dictionary
 ├── LICENSE  # MIT
 ├── package.json  # Library package, scripts, exports, bin
-├── pnpm-lock.yaml  # Root lockfile (pnpm 10.34.5)
+├── pnpm-lock.yaml  # Root lockfile (pnpm 11.24.0)
 ├── README.md  # Usage (App Router, Pages, API route, CLI)
 ├── renovate.json  # Dependency update policy
 ├── SECURITY.md  # Vulnerability reporting
@@ -96,7 +96,7 @@ codemap/  # next-swagger-doc — OpenAPI spec generator for Next.js API routes
 - `package.json`: Dual ESM/CJS `exports`, `main`/`module`/`types` pointing at `dist/`, `files: ["dist", "src"]`.
 
 **Configuration:**
-- `package.json`: Scripts (`build` pkgroll, `test` vitest, `lint`/`format` biome), engines `node >= 18`, peer `next >= 9`, packageManager `pnpm@10.34.5`.
+- `package.json`: Scripts (`build` pkgroll, `test` vitest, `lint`/`format` biome), engines `node >= 18`, peer `next >= 9`, packageManager `pnpm@11.24.0`.
 - `tsconfig.json`: `include: ["src", "types"]`, `strict`, `noEmit`, `rootDir: ./src`, `module: esnext`.
 - `vitest.config.ts`: `{ test: { globals: true } }`.
 - `biome.json`: Formatter (2-space, 80-col, single quotes for JS) and lint rules scoped to `src`; ignores `dist`.

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -5,7 +5,7 @@
 ## Test Framework
 
 **Runner:**
-- Vitest 3.2.7 (`vitest` / `@vitest/ui` / `@vitest/coverage-v8` in `package.json`)
+- Vitest 4.1.11 (`vitest` / `@vitest/ui` / `@vitest/coverage-v8` in `package.json`)
 - Config: `vitest.config.ts` (`test.globals: true` only — no custom environment, include, or coverage block)
 
 **Assertion Library:**
@@ -157,7 +157,7 @@ const autoPaths = {
 
 ## Coverage
 
-**Requirements:** None enforced. `vitest.config.ts` has no `coverage.thresholds`. `@vitest/coverage-v8` 3.2.7 is a devDependency; `c8` is listed but unused by scripts. Coverage output dir `coverage/` is gitignored in `.gitignore`.
+**Requirements:** None enforced. `vitest.config.ts` has no `coverage.thresholds`. `@vitest/coverage-v8` 4.1.11 is a devDependency; `c8` is listed but unused by scripts. Coverage output dir `coverage/` is gitignored in `.gitignore`.
 
 **View Coverage:**
 ```bash

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,52 +1,241 @@
-# TESTING — next-swagger-doc
+# Testing Patterns
 
-## Framework
+**Analysis Date:** 2026-08-26
 
-- **Vitest** 3.1.2, configured in `vitest.config.ts` with `globals: true` (describe/it/expect available globally)
-- Run with `pnpm test` (`vitest run`); UI mode via `pnpm test:ui`; coverage via `pnpm coverage` (`@vitest/coverage-v8`)
+## Test Framework
 
-## Test Layout
+**Runner:**
+- Vitest 3.2.7 (`vitest` / `@vitest/ui` / `@vitest/coverage-v8` in `package.json`)
+- Config: `vitest.config.ts` (`test.globals: true` only — no custom environment, include, or coverage block)
 
-- **Single test file**: `test/index.test.ts`
-- **Suites**: `describe('withSwagger', …)` containing all `it(...)` cases
-- **Snapshots**: `test/__snapshots__/index.test.ts.snap` (Vitest snapshot v1 format)
-- **Fixtures**: `test/fixtures/` mirrors real Next.js app structure:
-  - `app/**/route.ts` — source route files (App Router)
-  - `app/api/regex/route.ts` — route with a regex literal containing a comment-like sequence (regression fixture)
-  - `.next/server/app/**/route.js` — compiled route files (build-dir scanning)
+**Assertion Library:**
+- Vitest `expect` (imported from `vitest` in `test/index.test.ts`, even though globals are enabled)
 
-## What Is Tested
+**Run Commands:**
+```bash
+pnpm test              # Run all tests
+pnpm exec vitest       # Watch mode (no package script; `pnpm test` is `vitest run`)
+pnpm coverage          # Coverage
+```
 
-1. **Default spec generation** — `createSwaggerSpec` with a minimal definition → snapshot
-2. **Bearer auth** — `securitySchemes.bearerAuth` → snapshot
-3. **OAuth2 auth** — `securitySchemes.OAuth2` with flows → snapshot
-4. **App Router path/method extraction** — `extractApiInfo('test/fixtures/app')` returns exact sorted `{ path, methods }[]`, covering:
-   - static routes (`/api/health` → get, head; `/users` → get, post)
-   - dynamic segments (`/api/users/{id}` → patch, delete)
-   - optional catch-all (`/blog` + `/blog/{slug}`)
-   - `export { handler as GET, handler as POST }` re-export syntax
-   - commented-out handlers and strings containing `export function DELETE` (comment/string handling)
-   - regex literals containing comment-like sequences (`/api/regex` → get) — the case that broke the old hand-rolled scanner
-5. **Compiled-route scanning** — `extractApiInfo('app/only-compiled', 'test/fixtures')` reads `.next/server` `route.js` when source is absent
-6. **Auto-doc generation** — `autoDoc: true` produces default `200` responses; manual `@swagger` operations are **not** replaced
-7. **Narrowed folders** — `extractApiInfo('test/fixtures/app/api')` scopes to a subfolder
-8. **Missing directories** — `extractApiInfo('test/fixtures/missing')` returns `[]`
+`pnpm test:ui` (`vitest --ui`) is the interactive UI. There is no `test:watch` script in `package.json`.
 
-## Patterns
+## Test File Organization
 
-- **Snapshot testing** is the primary assertion style for spec output (`toMatchSnapshot`)
-- **Exact-equality assertions** (`toEqual`) for extraction results
-- **`toMatchObject`** for partial spec assertions (auto-doc merge test)
-- No mocking framework in use — tests are pure/functional against real filesystem fixtures
-- No test helpers or shared setup; each test is self-contained
+**Location:**
+- Separate `test/` tree (not co-located with `src/`). One suite file covers the whole library.
+
+**Naming:**
+- `test/index.test.ts` plus Vitest snapshots `test/__snapshots__/index.test.ts.snap`.
+- Fixture routes keep Next.js names: `route.ts` / compiled `route.js`.
+
+**Structure:**
+```
+test/
+  index.test.ts
+  __snapshots__/
+    index.test.ts.snap
+  fixtures/
+    app/                          # App Router source tree
+      api/health/route.ts
+      api/manual/route.ts         # JSDoc @swagger wins over autoDoc
+      api/regex/route.ts          # regex vs comment-stripping
+      api/users/[id]/route.ts     # dynamic segment
+      blog/[[...slug]]/route.ts   # optional catch-all
+      commented/route.ts
+      users/route.ts              # re-export / commented false-positive
+    .next/server/app/only-compiled/compiled/route.js  # compiled-only fallback
+```
+
+## Test Structure
+
+**Suite Organization:**
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import {
+  createSwaggerSpec,
+  extractApiInfo,
+  isAutoDocEnabled,
+  shouldScanBuildDirectory,
+} from '../src';
+import { mergeAutoDoc } from '../src/merge-auto-doc';
+
+describe('withSwagger', () => {
+  it('extracts App Router paths and exported HTTP methods', () => {
+    expect(extractApiInfo('test/fixtures/app')).toEqual([
+      { path: '/api/health', methods: ['get', 'head'] },
+      { path: '/api/users/{id}', methods: ['patch', 'delete'] },
+    ]);
+  });
+});
+
+describe('mergeAutoDoc', () => {
+  it('keeps manual and auto-only paths and lets manual win per method', () => {
+    expect(mergeAutoDoc(autoPaths, manualPaths)).toEqual({ /* ... */ });
+  });
+});
+```
+
+Suites in `test/index.test.ts` are grouped by symbol or feature: `withSwagger`, `shouldScanBuildDirectory`, `isAutoDocEnabled`, `standalone spec files`, `routeToOpenApiPaths`, `discoverSpecLocations`, `mergeAutoDoc`.
+
+**Patterns:**
+- Setup pattern: public API imported from `../src`; internals imported from their modules (`../src/merge-auto-doc`, `../src/route-path`, `../src/spec-source`). Filesystem cases create a temp dir with `mkdtempSync(join(tmpdir(), 'swagger-scan-'))` in `test/index.test.ts`.
+- Teardown pattern: `try { ... } finally { rmSync(root, { recursive: true, force: true }); }` — no `beforeEach` / `afterEach` / `beforeAll`.
+- Assertion pattern: `toEqual` for exact structures; `toMatchObject` for partial OpenAPI paths; `toMatchSnapshot` for full `createSwaggerSpec` documents; `toBe` for booleans/primitives; `toBeDefined` for path presence. Older cases use `should ...` names; newer ones use present-tense verbs (`extracts`, `skips`, `honors`, `merges`).
+
+## Mocking
+
+**Framework:** None. No `vi.mock`, `jest.mock`, or fake timers appear in `test/index.test.ts`.
+
+**Patterns:**
+```typescript
+// Prefer a real fixture tree over a mocked fs:
+expect(extractApiInfo('test/fixtures/app/api/regex')).toEqual([
+  { path: '/api/regex', methods: ['get'] },
+]);
+
+// When the filesystem must be isolated, use a real temp directory:
+const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+try {
+  writeFileSync(specFile, JSON.stringify({ openapi: '3.0.0', /* ... */ }));
+  const spec = createSwaggerSpec({ specFile, /* ... */ });
+  expect(spec.info.title).toBe('Standalone');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+```
+
+**What to Mock:**
+- Do not introduce mocks for `fs`, `swagger-jsdoc`, or route parsing unless a new test cannot use a fixture or temp dir.
+- Inject `cwd` / `nextPhase` arguments (`extractApiInfo(..., 'test/fixtures')`, `shouldScanBuildDirectory({ nextPhase: 'phase-production-build' })` in `test/index.test.ts`) instead of stubbing `process.env` or `process.cwd()`.
+
+**What NOT to Mock:**
+- App Router `route` modules — use `test/fixtures/**/route.ts`.
+- Compiled output — use `test/fixtures/.next/server/app/only-compiled/compiled/route.js`.
+- `createSwaggerSpec` / `swagger-jsdoc` — run the real pipeline and assert `spec.paths` or snapshots.
+- `mergeAutoDoc`, `routeToOpenApiPaths`, `discoverSpecLocations` — call the real functions with in-memory objects.
+
+## Fixtures and Factories
+
+**Test Data:**
+```typescript
+// Real Next.js handlers under test/fixtures/app/api/health/route.ts
+export function GET() {
+  return Response.json({ status: 'ok' });
+}
+export async function HEAD() {
+  return new Response(null);
+}
+
+// Manual JSDoc wins when autoDoc is on (test/fixtures/app/api/manual/route.ts)
+/**
+ * @swagger
+ * /api/manual:
+ *   get:
+ *     summary: Manual documentation
+ *     responses:
+ *       204:
+ *         description: No content
+ */
+export function GET() {
+  return new Response(null, { status: 204 });
+}
+
+// Inline objects for pure unit cases (test/index.test.ts mergeAutoDoc):
+const autoPaths = {
+  '/api/health': { get: { summary: 'GET /api/health' } },
+};
+```
+
+**Location:**
+- On-disk App Router trees: `test/fixtures/app/` (dynamic `[id]`, optional catch-all `[[...slug]]`, commented exports, regex literals, alias re-exports).
+- Compiled-only fallback: `test/fixtures/.next/server/app/only-compiled/compiled/route.js` (consumed via `extractApiInfo('app/only-compiled', 'test/fixtures')` in `test/index.test.ts`).
+- Snapshot golden files: `test/__snapshots__/index.test.ts.snap`.
+- Ad-hoc JSON specs and output files are written into `os.tmpdir()` during the test, not checked in.
+- AGENTS.md: prefer these real fixtures over mocks.
 
 ## Coverage
 
-- Coverage tooling present (`@vitest/coverage-v8`, `c8`), but no coverage thresholds configured and no coverage CI gate
+**Requirements:** None enforced. `vitest.config.ts` has no `coverage.thresholds`. `@vitest/coverage-v8` 3.2.7 is a devDependency; `c8` is listed but unused by scripts. Coverage output dir `coverage/` is gitignored in `.gitignore`.
 
-## Gaps / Notes
+**View Coverage:**
+```bash
+pnpm coverage
+```
 
-- `.swm/testing-overview.b1r1n.sw.md` (Swimm doc) claims Playwright E2E tests exist — **no Playwright config or E2E tests are present in the repo** (stale doc)
-- No CI workflow runs the test suite (only CodeQL + CodeSee workflows exist)
-- No tests for the CLI (`src/cli.ts`) or for `withSwagger`'s error path
-- `src/swagger.ts` base-path injection (`__NEXT_ROUTER_BASEPATH`) is untested
+(`vitest run --coverage` from `package.json`). Default v8 reporter; no custom include/exclude in `vitest.config.ts`.
+
+## Test Types
+
+**Unit Tests:**
+- Pure functions with in-memory inputs in `test/index.test.ts`: `mergeAutoDoc`, `routeToOpenApiPaths`, `discoverSpecLocations`, `isAutoDocEnabled`.
+- Filesystem predicates (`shouldScanBuildDirectory`) use temp directories, not the repo tree.
+- Scope is one function per `describe`; assertions are exact `toEqual` / `toBe`.
+
+**Integration Tests:**
+- `createSwaggerSpec` + `extractApiInfo` against `test/fixtures/app` and `test/fixtures/app/api`, including `autoDoc: true` merge with JSDoc `@swagger` in `test/fixtures/app/api/manual/route.ts`.
+- Standalone `specFile` / `outputFile` round-trips write and read real JSON.
+- Compiled-route discovery hits `test/fixtures/.next/...`.
+- Full spec shape for auth examples is locked with snapshots in `test/__snapshots__/index.test.ts.snap`.
+
+**E2E Tests:**
+- Not used. Example apps under `examples/next13-simple`, `examples/next14-app`, `examples/next15-app`, `examples/next16-app` are demos with their own lockfiles; AGENTS.md says library changes are verified with `pnpm test` at the repo root, not by running those apps.
+
+## Common Patterns
+
+**Async Testing:**
+```typescript
+// Tests are synchronous. createSwaggerSpec, extractApiInfo, and fs helpers
+// used in test/index.test.ts are sync (readFileSync / writeFileSync).
+it('writes the generated spec to outputFile', () => {
+  const spec = createSwaggerSpec({
+    apiFolder: 'test/fixtures/app/api',
+    autoDoc: true,
+    outputFile,
+    definition: { openapi: '3.0.0', info: { title: 'Written', version: '1.0.0' } },
+  });
+  const saved = JSON.parse(readFileSync(outputFile, 'utf8')) as {
+    info: { title: string };
+  };
+  expect(saved.info.title).toBe('Written');
+  expect(spec.info.title).toBe('Written');
+});
+```
+
+Do not add `async`/`await` unless the production API becomes async. Fixture handlers may be `async` (`HEAD` / `PATCH` in `test/fixtures/app/api/health/route.ts` and `test/fixtures/app/api/users/[id]/route.ts`); the extractor only cares about export names.
+
+**Error Testing:**
+```typescript
+// No `expect().toThrow()` in test/index.test.ts. Empty/invalid inputs
+// are asserted as empty results or boolean false:
+
+it('ignores a missing App Router directory', () => {
+  expect(extractApiInfo('test/fixtures/missing')).toEqual([]);
+});
+
+it('keeps autoDoc off when source files exist', () => {
+  expect(isAutoDocEnabled(undefined, false)).toBe(false);
+  expect(isAutoDocEnabled(false, true)).toBe(false);
+});
+
+it('skips missing build directories', () => {
+  const root = mkdtempSync(join(tmpdir(), 'swagger-scan-'));
+  try {
+    expect(
+      shouldScanBuildDirectory({
+        sourceDirectory: join(root, 'app/api'),
+        buildDirectory: join(root, '.next/server/app/api'),
+      })
+    ).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+```
+
+`withSwagger`'s `try/catch` 400 path in `src/swagger.ts` and `getExportedMethods` parse warnings in `src/route-parser.ts` are not covered by dedicated throw tests.
+
+---
+
+*Testing analysis: 2026-08-26*


### PR DESCRIPTION
## What

Refresh the seven `.planning/codebase/` documents (STACK, INTEGRATIONS, ARCHITECTURE, STRUCTURE, CONVENTIONS, TESTING, CONCERNS) to the current mapper templates.

## Why

The previous map did not follow the templates and drifted from `src/`. Later plan PRs in this stack are grounded in the vetted CONCERNS.md from this refresh.

## How

Parallel mapper agents filled the templates against the live tree at `b87cecb`. Docs only — no `src/` changes.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
