### PR TITLE
fix: skip compiled autoDoc scan during Next.js builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js app
 
 ### Vercel builds
 
-`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public` OpenAPI files are scanned instead. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
+`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public` OpenAPI files are scanned instead. `autoDoc` / `extractApiInfo` use the same `shouldScanBuildDirectory` gate, so compiled `route.js` handlers are not merged while a production build is rewriting `.next`. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
 
 ### Next.js standalone output
 

--- a/src/auto-doc.ts
+++ b/src/auto-doc.ts
@@ -3,7 +3,10 @@ import { join, relative, sep } from 'node:path';
 
 import { HTTP_METHODS, getExportedMethods } from './route-parser';
 import { routeToOpenApiPaths } from './route-path';
-import { discoverSpecLocations } from './spec-source';
+import {
+  discoverSpecLocations,
+  shouldScanBuildDirectory,
+} from './spec-source';
 
 export type ApiInfo = {
   path: string;
@@ -29,10 +32,32 @@ function getRouteFiles(directory: string): string[] {
 /** Extract App Router API paths and exported HTTP methods from route files. */
 export function extractApiInfo(
   apiFolder: string,
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  options?: { scanBuildOutput?: boolean; nextPhase?: string }
 ): ApiInfo[] {
   const { sourceDirs, buildDirs } = discoverSpecLocations([apiFolder], cwd);
-  const directories = [...sourceDirs, ...buildDirs].filter(existsSync);
+  const directories: string[] = [];
+  for (let index = 0; index < sourceDirs.length; index += 1) {
+    const sourceDirectory = sourceDirs[index];
+    if (!sourceDirectory) {
+      continue;
+    }
+    if (existsSync(sourceDirectory)) {
+      directories.push(sourceDirectory);
+    }
+    const buildDirectory = buildDirs[index];
+    if (
+      buildDirectory &&
+      shouldScanBuildDirectory({
+        sourceDirectory,
+        buildDirectory,
+        scanBuildOutput: options?.scanBuildOutput,
+        nextPhase: options?.nextPhase,
+      })
+    ) {
+      directories.push(buildDirectory);
+    }
+  }
   const apiInfos = new Map<string, Set<string>>();
 
   for (const apiDirectory of directories) {

--- a/src/spec-source.ts
+++ b/src/spec-source.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 export type SpecLocations = {
@@ -5,6 +6,43 @@ export type SpecLocations = {
   buildDirs: string[];
   publicDir: string;
 };
+
+/** Next.js phases that rewrite `.next` and must not be scanned. */
+const NEXT_BUILD_PHASES = new Set([
+  'phase-production-build',
+  'phase-production-compile',
+  'phase-export',
+]);
+
+/**
+ * Whether compiled files under `.next/server` should be scanned.
+ *
+ * Globbing `.next` while Next.js is compiling can fail Vercel builds with
+ * `ENOENT: .../.next/export-detail.json`. Prefer source files; scan compiled
+ * output only as a runtime fallback when the source folder is gone.
+ */
+export function shouldScanBuildDirectory({
+  sourceDirectory,
+  buildDirectory,
+  scanBuildOutput,
+  nextPhase = process.env.NEXT_PHASE,
+}: {
+  sourceDirectory: string;
+  buildDirectory: string;
+  scanBuildOutput?: boolean;
+  nextPhase?: string;
+}): boolean {
+  if (!existsSync(buildDirectory) || scanBuildOutput === false) {
+    return false;
+  }
+  if (scanBuildOutput === true) {
+    return true;
+  }
+  if (nextPhase && NEXT_BUILD_PHASES.has(nextPhase)) {
+    return false;
+  }
+  return !existsSync(sourceDirectory);
+}
 
 /**
  * Discover where route documentation can live for a set of folders.

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -4,7 +4,12 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import swaggerJsdoc, { type OAS3Definition, type Options } from 'swagger-jsdoc';
 import { extractApiInfo, generateAutoDoc } from './auto-doc';
 import { mergeAutoDoc } from './merge-auto-doc';
-import { discoverSpecLocations } from './spec-source';
+import {
+  discoverSpecLocations,
+  shouldScanBuildDirectory,
+} from './spec-source';
+
+export { shouldScanBuildDirectory };
 
 export type AutoDocOptions = {
   enabled?: boolean;
@@ -31,43 +36,6 @@ export type SwaggerOptions = Options & {
    */
   scanBuildOutput?: boolean;
 };
-
-/** Next.js phases that rewrite `.next` and must not be globbed. */
-const NEXT_BUILD_PHASES = new Set([
-  'phase-production-build',
-  'phase-production-compile',
-  'phase-export',
-]);
-
-/**
- * Whether compiled files under `.next/server` should be globbed.
- *
- * Globbing `.next` while Next.js is compiling can fail Vercel builds with
- * `ENOENT: .../.next/export-detail.json`. Prefer source files; scan compiled
- * output only as a runtime fallback when the source folder is gone.
- */
-export function shouldScanBuildDirectory({
-  sourceDirectory,
-  buildDirectory,
-  scanBuildOutput,
-  nextPhase = process.env.NEXT_PHASE,
-}: {
-  sourceDirectory: string;
-  buildDirectory: string;
-  scanBuildOutput?: boolean;
-  nextPhase?: string;
-}): boolean {
-  if (!existsSync(buildDirectory) || scanBuildOutput === false) {
-    return false;
-  }
-  if (scanBuildOutput === true) {
-    return true;
-  }
-  if (nextPhase && NEXT_BUILD_PHASES.has(nextPhase)) {
-    return false;
-  }
-  return !existsSync(sourceDirectory);
-}
 
 /** Resolve a user-supplied path against the process working directory. */
 function resolveUserPath(file: string, cwd = process.cwd()): string {
@@ -197,7 +165,9 @@ export function createSwaggerSpec({
   const sourceDirectory = join(process.cwd(), apiFolder);
 
   if (isAutoDocEnabled(autoDoc, !existsSync(sourceDirectory))) {
-    const autoPaths = generateAutoDoc(extractApiInfo(apiFolder));
+    const autoPaths = generateAutoDoc(
+      extractApiInfo(apiFolder, process.cwd(), { scanBuildOutput })
+    );
     spec.paths = mergeAutoDoc(autoPaths, spec.paths ?? {}) as OAS3Definition['paths'];
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -257,6 +257,97 @@ describe('shouldScanBuildDirectory', () => {
   });
 });
 
+describe('extractApiInfo scan gate', () => {
+  const writeRoute = (file: string, method: string) => {
+    mkdirSync(join(file, '..'), { recursive: true });
+    writeFileSync(file, `export function ${method}() {}\n`);
+  };
+
+  it('ignores compiled methods when source files exist', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-extract-'));
+    try {
+      writeRoute(join(root, 'app/api/hello/route.ts'), 'GET');
+      writeRoute(
+        join(root, '.next/server/app/api/hello/route.js'),
+        'OPTIONS'
+      );
+      expect(extractApiInfo('app/api', root)).toEqual([
+        { path: '/api/hello', methods: ['get'] },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts compiled routes when source files are missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-extract-'));
+    try {
+      writeRoute(
+        join(root, '.next/server/app/api/hello/route.js'),
+        'OPTIONS'
+      );
+      expect(extractApiInfo('app/api', root)).toEqual([
+        { path: '/api/hello', methods: ['options'] },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('unions compiled methods when scanBuildOutput is true', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-extract-'));
+    try {
+      writeRoute(join(root, 'app/api/hello/route.ts'), 'GET');
+      writeRoute(
+        join(root, '.next/server/app/api/hello/route.js'),
+        'OPTIONS'
+      );
+      expect(
+        extractApiInfo('app/api', root, { scanBuildOutput: true })
+      ).toEqual([{ path: '/api/hello', methods: ['get', 'options'] }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips compiled methods during a production build phase', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-extract-'));
+    try {
+      writeRoute(join(root, 'app/api/hello/route.ts'), 'GET');
+      writeRoute(
+        join(root, '.next/server/app/api/hello/route.js'),
+        'OPTIONS'
+      );
+      expect(
+        extractApiInfo('app/api', root, {
+          nextPhase: 'phase-production-build',
+        })
+      ).toEqual([{ path: '/api/hello', methods: ['get'] }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('lets scanBuildOutput override a production build phase', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-extract-'));
+    try {
+      writeRoute(join(root, 'app/api/hello/route.ts'), 'GET');
+      writeRoute(
+        join(root, '.next/server/app/api/hello/route.js'),
+        'OPTIONS'
+      );
+      expect(
+        extractApiInfo('app/api', root, {
+          scanBuildOutput: true,
+          nextPhase: 'phase-production-build',
+        })
+      ).toEqual([{ path: '/api/hello', methods: ['get', 'options'] }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('isAutoDocEnabled', () => {
   it('keeps autoDoc off when source files exist', () => {
     expect(isAutoDocEnabled(undefined, false)).toBe(false);


### PR DESCRIPTION
## What

Gate `extractApiInfo` with `shouldScanBuildDirectory` (moved to `src/spec-source.ts`).

## Why

autoDoc still walked `.next/server` during `next build`, the leftover hole from #1157 / #1248.

## How

Source methods win when source exists. Compiled fallback remains when source is missing. `scanBuildOutput: true` still unions. Five temp-dir tests.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
