### PR TITLE
fix: create CLI output directories and report config errors

### DIFF
--- a/src/cli-write.ts
+++ b/src/cli-write.ts
@@ -1,11 +1,6 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, isAbsolute, join } from 'node:path';
+import { readFileSync } from 'node:fs';
 
 import { type SwaggerOptions, createSwaggerSpec } from './swagger';
-
-function resolveOutputPath(outputFile: string, cwd = process.cwd()): string {
-  return isAbsolute(outputFile) ? outputFile : join(cwd, outputFile);
-}
 
 /** Generate a spec from a JSON config file and write it to `outputFile`. */
 export function writeCliSpec(configFile: string, outputFile: string): void {
@@ -19,10 +14,5 @@ export function writeCliSpec(configFile: string, outputFile: string): void {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Config file must contain a JSON object');
   }
-  const { outputFile: _ignored, ...swaggerOptions } =
-    parsed as SwaggerOptions;
-  const spec = createSwaggerSpec(swaggerOptions);
-  const outputPath = resolveOutputPath(outputFile);
-  mkdirSync(dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, JSON.stringify(spec, null, 2));
+  createSwaggerSpec({ ...(parsed as SwaggerOptions), outputFile });
 }

--- a/src/cli-write.ts
+++ b/src/cli-write.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
+
+import { type SwaggerOptions, createSwaggerSpec } from './swagger';
+
+function resolveOutputPath(outputFile: string, cwd = process.cwd()): string {
+  return isAbsolute(outputFile) ? outputFile : join(cwd, outputFile);
+}
+
+/** Generate a spec from a JSON config file and write it to `outputFile`. */
+export function writeCliSpec(configFile: string, outputFile: string): void {
+  const configRaw = readFileSync(configFile, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configRaw);
+  } catch {
+    throw new Error(`Invalid JSON in config file ${configFile}`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Config file must contain a JSON object');
+  }
+  const { outputFile: _ignored, ...swaggerOptions } =
+    parsed as SwaggerOptions;
+  const spec = createSwaggerSpec(swaggerOptions);
+  const outputPath = resolveOutputPath(outputFile);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(spec, null, 2));
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,22 +1,16 @@
-import { readFileSync, writeFileSync } from 'fs';
 import { cli } from 'cleye';
 
-import { type SwaggerOptions, createSwaggerSpec } from './swagger';
+import { writeCliSpec } from './cli-write';
 
-// Parse argv
 const argv = cli({
   name: 'next-swagger-doc-cli',
 
-  // Define parameters
-  // Becomes available in ._.filePath
+  // Becomes available in ._.configFile
   parameters: [
     '<config file>', // Next swagger config file is required
   ],
 
-  // Define flags/options
-  // Becomes available in .flags
   flags: {
-    // Parses `--output` as a string
     output: {
       type: String,
       description: 'Output file path',
@@ -25,14 +19,12 @@ const argv = cli({
   },
 });
 
-const config = readFileSync(argv._.configFile);
-
-const spec = createSwaggerSpec(
-  JSON.parse(config.toString()) as unknown as SwaggerOptions
-);
-
-console.log(
-  `Generating swagger spec to ${argv.flags.output} with config`,
-  config.toString()
-);
-writeFileSync(argv.flags.output, JSON.stringify(spec, null, 2));
+try {
+  writeCliSpec(argv._.configFile, argv.flags.output);
+  console.log(`Generating swagger spec to ${argv.flags.output}`);
+} catch (error) {
+  const message =
+    error instanceof Error ? error.message : 'Failed to generate swagger spec';
+  console.error(message);
+  process.exitCode = 1;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -17,6 +18,7 @@ import {
 } from '../src';
 import { mergeAutoDoc } from '../src/merge-auto-doc';
 import { routeToOpenApiPaths } from '../src/route-path';
+import { writeCliSpec } from '../src/cli-write';
 import { discoverSpecLocations } from '../src/spec-source';
 
 describe('withSwagger', () => {
@@ -511,5 +513,81 @@ describe('mergeAutoDoc', () => {
     expect(mergeAutoDoc({}, manual)).toEqual(manual);
     const auto = { '/api/a': { get: { summary: 'a' } } };
     expect(mergeAutoDoc(auto, {})).toEqual(auto);
+  });
+});
+
+describe('writeCliSpec', () => {
+  const writeConfig = (file: string, value: unknown) => {
+    writeFileSync(file, JSON.stringify(value));
+  };
+
+  it('creates nested output directories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-cli-'));
+    const outputFile = join(root, 'public/swagger.json');
+    const configFile = join(root, 'next-swagger-doc.json');
+    try {
+      writeConfig(configFile, {
+        apiFolder: 'test/fixtures/app/api',
+        autoDoc: true,
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'CLI', version: '1.0.0' },
+        },
+      });
+      writeCliSpec(configFile, outputFile);
+      const saved = JSON.parse(readFileSync(outputFile, 'utf8')) as {
+        info: { title: string };
+      };
+      expect(saved.info.title).toBe('CLI');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on invalid JSON config', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-cli-'));
+    const configFile = join(root, 'next-swagger-doc.json');
+    try {
+      writeFileSync(configFile, 'not-json');
+      expect(() =>
+        writeCliSpec(configFile, join(root, 'out.json'))
+      ).toThrow(/Invalid JSON/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when the config file is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-cli-'));
+    try {
+      expect(() =>
+        writeCliSpec(join(root, 'missing.json'), join(root, 'out.json'))
+      ).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write config outputFile when CLI output is set', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-cli-'));
+    const configFile = join(root, 'next-swagger-doc.json');
+    const fromConfig = join(root, 'from-config.json');
+    const fromFlag = join(root, 'from-flag.json');
+    try {
+      writeConfig(configFile, {
+        apiFolder: 'test/fixtures/app/api',
+        autoDoc: true,
+        outputFile: fromConfig,
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'CLI', version: '1.0.0' },
+        },
+      });
+      writeCliSpec(configFile, fromFlag);
+      expect(existsSync(fromFlag)).toBe(true);
+      expect(existsSync(fromConfig)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## What

Extract `writeCliSpec` so the CLI creates parent directories and fails clearly.

## Why

`npx next-swagger-doc-cli … --output public/swagger.json` threw if `public/` was missing.

## How

`mkdirSync` recursive; invalid JSON throws; config `outputFile` is ignored so `--output` is the only write.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
