### PR TITLE
fix: reject invalid specFile JSON

### DIFF
--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -54,9 +54,10 @@ export function loadSpecFile(
   if (!existsSync(specPath)) {
     return undefined;
   }
+  const contents = readFileSync(specPath, 'utf8');
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(specPath, 'utf8'));
+    parsed = JSON.parse(contents);
   } catch {
     throw new Error(`Invalid JSON in specFile ${specPath}`);
   }

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -54,7 +54,27 @@ export function loadSpecFile(
   if (!existsSync(specPath)) {
     return undefined;
   }
-  return JSON.parse(readFileSync(specPath, 'utf8')) as OAS3Definition;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(specPath, 'utf8'));
+  } catch {
+    throw new Error(`Invalid JSON in specFile ${specPath}`);
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed)
+  ) {
+    throw new Error(`specFile is not an OpenAPI object: ${specPath}`);
+  }
+  const document = parsed as Record<string, unknown>;
+  if (
+    typeof document.openapi !== 'string' &&
+    typeof document.swagger !== 'string'
+  ) {
+    throw new Error(`specFile is not an OpenAPI object: ${specPath}`);
+  }
+  return parsed as OAS3Definition;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,6 +16,7 @@ import {
   createSwaggerSpec,
   extractApiInfo,
   isAutoDocEnabled,
+  loadSpecFile,
   shouldScanBuildDirectory,
   withSwagger,
 } from '../src';
@@ -416,6 +417,72 @@ describe('standalone spec files', () => {
       };
       expect(saved.info.title).toBe('Written');
       expect(spec.info.title).toBe('Written');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when specFile is invalid JSON', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+    const specFile = join(root, 'swagger.json');
+    try {
+      writeFileSync(specFile, 'not-json');
+      expect(() =>
+        createSwaggerSpec({
+          specFile,
+          definition: {
+            openapi: '3.0.0',
+            info: { title: 'x', version: '1' },
+          },
+        })
+      ).toThrow(/Invalid JSON/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when specFile is an empty object', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+    const specFile = join(root, 'swagger.json');
+    try {
+      writeFileSync(specFile, '{}');
+      expect(() =>
+        createSwaggerSpec({
+          specFile,
+          definition: {
+            openapi: '3.0.0',
+            info: { title: 'x', version: '1' },
+          },
+        })
+      ).toThrow(/not an OpenAPI object/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when specFile is a JSON array', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+    const specFile = join(root, 'swagger.json');
+    try {
+      writeFileSync(specFile, '[]');
+      expect(() =>
+        createSwaggerSpec({
+          specFile,
+          definition: {
+            openapi: '3.0.0',
+            info: { title: 'x', version: '1' },
+          },
+        })
+      ).toThrow(/not an OpenAPI object/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns undefined when specFile is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-spec-'));
+    try {
+      expect(loadSpecFile(join(root, 'missing.json'), root)).toBeUndefined();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What

`loadSpecFile` rejects invalid JSON and non-OpenAPI objects.

## Why

Truncated JSON threw raw SyntaxError; `{}` was served as a spec (#1163 / #1164).

## How

Missing file still returns undefined. Require an object with `openapi` or `swagger` string.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
