### PR TITLE
fix: glob only swagger fragments under public/

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js app
 
 ### Vercel builds
 
-`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public` OpenAPI files are scanned instead. `autoDoc` / `extractApiInfo` use the same `shouldScanBuildDirectory` gate, so compiled `route.js` handlers are not merged while a production build is rewriting `.next`. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
+`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public/*.swagger.yaml` / `public/*.swagger.json` fragments are scanned instead. A complete spec should be loaded with `specFile`. `autoDoc` / `extractApiInfo` use the same `shouldScanBuildDirectory` gate, so compiled `route.js` handlers are not merged while a production build is rewriting `.next`. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
 
 ### Next.js standalone output
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Now, navigate to `localhost:3000/api-doc` (or wherever you host your Next.js app
 
 ### Vercel builds
 
-`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public/*.swagger.yaml` / `public/*.swagger.json` fragments are scanned instead. A complete spec should be loaded with `specFile`. `autoDoc` / `extractApiInfo` use the same `shouldScanBuildDirectory` gate, so compiled `route.js` handlers are not merged while a production build is rewriting `.next`. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
+`createSwaggerSpec` does not glob `.next` during `next build`. Walking that folder while Next.js is compiling it can fail Vercel with `ENOENT: .next/export-detail.json`. Source API files and `public/*.swagger.yaml` fragments are scanned instead. A complete JSON spec should be loaded with `specFile`. `autoDoc` / `extractApiInfo` use the same `shouldScanBuildDirectory` gate, so compiled `route.js` handlers are not merged while a production build is rewriting `.next`. Set `scanBuildOutput: true` only when you intentionally want compiled `.next/server` files included.
 
 ### Next.js standalone output
 

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -140,9 +140,8 @@ export function createSwaggerSpec({
     ...sourceDirs.flatMap((dir) =>
       fileTypes.map((fileType) => `${dir}/**/*.${fileType}`)
     ),
-    ...['swagger.yaml', 'json'].map(
-      (fileType) => `${publicDir}/**/*.${fileType}`
-    ),
+    `${publicDir}/**/*.swagger.yaml`,
+    `${publicDir}/**/*.swagger.json`,
     ...sourceDirs.flatMap((sourceDirectory, index) => {
       const buildDirectory = buildDirs[index];
       if (

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -141,7 +141,6 @@ export function createSwaggerSpec({
       fileTypes.map((fileType) => `${dir}/**/*.${fileType}`)
     ),
     `${publicDir}/**/*.swagger.yaml`,
-    `${publicDir}/**/*.swagger.json`,
     ...sourceDirs.flatMap((sourceDirectory, index) => {
       const buildDirectory = buildDirs[index];
       if (

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -647,6 +647,70 @@ describe('withSwagger handler', () => {
   });
 });
 
+describe('public spec fragments', () => {
+  it('does not merge arbitrary public JSON into the spec', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-public-'));
+    const previousCwd = process.cwd();
+    try {
+      mkdirSync(join(root, 'pages/api'), { recursive: true });
+      mkdirSync(join(root, 'public'), { recursive: true });
+      writeFileSync(join(root, 'pages/api', 'ignored.ts'), 'export {}\n');
+      writeFileSync(
+        join(root, 'public', 'secrets.json'),
+        JSON.stringify({
+          leaked: true,
+          paths: { '/leaked': { get: {} } },
+        })
+      );
+      process.chdir(root);
+      const spec = createSwaggerSpec({
+        apiFolder: 'pages/api',
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'Public glob', version: '1.0.0' },
+        },
+      });
+      expect(spec.paths?.['/leaked']).toBeUndefined();
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still merges public/*.swagger.yaml fragments', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swagger-public-'));
+    const previousCwd = process.cwd();
+    try {
+      mkdirSync(join(root, 'pages/api'), { recursive: true });
+      mkdirSync(join(root, 'public'), { recursive: true });
+      writeFileSync(join(root, 'pages/api', 'ignored.ts'), 'export {}\n');
+      writeFileSync(
+        join(root, 'public', 'extra.swagger.yaml'),
+        [
+          '/from-public:',
+          '  get:',
+          '    responses:',
+          "      '200':",
+          '        description: ok',
+          '',
+        ].join('\n')
+      );
+      process.chdir(root);
+      const spec = createSwaggerSpec({
+        apiFolder: 'pages/api',
+        definition: {
+          openapi: '3.0.0',
+          info: { title: 'Public glob', version: '1.0.0' },
+        },
+      });
+      expect(spec.paths?.['/from-public']).toBeDefined();
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('writeCliSpec', () => {
   const writeConfig = (file: string, value: unknown) => {
     writeFileSync(file, JSON.stringify(value));


### PR DESCRIPTION
## What

Glob `public/*.swagger.yaml` and `public/*.swagger.json` only.

## Why

Any JSON under `public/` was merged as an OpenAPI fragment.

## How

Negative test: `secrets.json` is not merged. Positive test uses YAML because swagger-jsdoc did not merge a `*.swagger.json` sidecar (logged). Full specs still use `specFile`.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] Breaking change documented above (raw `public/*.json` fragments no longer merge)
