### PR TITLE
chore: require Node.js >=20 to match swagger-jsdoc

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -15,13 +15,13 @@ run_step() {
 }
 
 if ! command -v node >/dev/null; then
-  echo "Node.js 18 or newer is required." >&2
+  echo "Node.js 20 or newer is required." >&2
   exit 1
 fi
 
 node_major="$(node -p 'process.versions.node.split(".")[0]')"
-if (( node_major < 18 )); then
-  echo "Node.js 18 or newer is required; found $(node --version)." >&2
+if (( node_major < 20 )); then
+  echo "Node.js 20 or newer is required; found $(node --version)." >&2
   exit 1
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Instructions for AI coding agents working on `next-swagger-doc`.
 
 Generate an OpenAPI (Swagger) spec from Next.js API routes. JSDoc `@swagger` blocks are parsed by `swagger-jsdoc`. App Router `route.ts` files can also get basic operations from folder paths and exported HTTP handlers when `autoDoc` is enabled.
 
-- Runtime: Node.js >= 18 (Next.js 16 example apps need Node.js >= 20.9)
+- Runtime: Node.js >= 20 (Next.js 16 example apps need Node.js >= 20.9)
 - Package manager: pnpm 10.34.5 (Corepack)
 - Language: TypeScript (strict, ESM)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Version](https://img.shields.io/npm/v/next-swagger-doc.svg)](https://npmjs.org/package/next-swagger-doc)
 [![Downloads/week](https://img.shields.io/npm/dw/next-swagger-doc.svg)](https://npmjs.org/package/next-swagger-doc)
-![Prerequisite](https://img.shields.io/badge/node-%3E%3D18-blue.svg)
+![Prerequisite](https://img.shields.io/badge/node-%3E%3D20-blue.svg)
 [![Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](http://next-swagger-doc.productsway.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#)
 [![Twitter: jellydn](https://img.shields.io/twitter/follow/jellydn.svg?style=social)](https://twitter.com/jellydn)
@@ -24,7 +24,7 @@
 ## Prerequisites
 
 - Nextjs >= 9
-- Node >= 18
+- Node >= 20
 
 ## Motivation
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "packageManager": "pnpm@10.34.5",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## What

Advertise Node.js `>=20` in engines, README, and AGENTS.md.

## Why

`swagger-jsdoc@6.3.0` already requires Node 20; claiming 18 was false.

## How

Docs/manifest only. `peerDependencies.next` unchanged.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
