### PR TITLE
chore: remove unused isarray dependency

### DIFF
--- a/examples/next13-simple/package.json
+++ b/examples/next13-simple/package.json
@@ -13,7 +13,6 @@
     "@stoplight/elements": "9.0.1",
     "@xstyled/styled-components": "4.0.0",
     "@xstyled/system": "3.8.1",
-    "isarray": "2.0.5",
     "next": "13.5.6",
     "next-swagger-doc": "github:jellydn/next-swagger-doc#v0.4.2-beta.0",
     "react": "18.3.1",

--- a/examples/next13-simple/pnpm-lock.yaml
+++ b/examples/next13-simple/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@xstyled/system':
         specifier: 3.8.1
         version: 3.8.1
-      isarray:
-        specifier: 2.0.5
-        version: 2.0.5
       next:
         specifier: 13.5.6
         version: 13.5.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/swagger-jsdoc": "6.0.4",
     "cleye": "1.3.4",
     "es-module-lexer": "2.3.2",
-    "isarray": "2.0.5",
     "swagger-jsdoc": "6.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       es-module-lexer:
         specifier: 2.3.2
         version: 2.3.2
-      isarray:
-        specifier: 2.0.5
-        version: 2.0.5
       swagger-jsdoc:
         specifier: 6.3.0
         version: 6.3.0(openapi-types@12.1.3)
@@ -1467,9 +1464,6 @@ packages:
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3295,8 +3289,6 @@ snapshots:
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.9
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
## What

Remove unused `isarray` from the library and the next13 example package.json.

## Why

Nothing in `src/` imported it.

## How

`pnpm remove isarray` (lockfile -8 lines). Example lockfile not regenerated.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)
